### PR TITLE
Type directly-addressed arrays as jsonArray + restore converter.ts coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,208 @@
+# CLAUDE.md — @rljson/converter
+
+Converts flat/tree-shaped textual data (JSON) into the layer-based RLJSON data
+model via a declarative **Decompose Chart**. The public surface is a single
+function, `fromJson(json, chart)` ([src/converter.ts](src/converter.ts)).
+
+Downstream package — depends on `@rljson/rljson`, `@rljson/json`,
+`@rljson/hash`. When those publish a new version, run `pnpm update --latest`
+here before your own publish.
+
+---
+
+## Non-Negotiable Constraints
+
+- **Never commit directly to `main`.** Always work on a feature branch and land
+  changes through a PR (see Ticket Workflow). No exceptions, no hotfixes on main.
+- **Never modify the `scripts` section in `package.json`** without explicit user
+  permission.
+- **100% test coverage** on all new/modified `src/` files (Statements, Branches,
+  Functions, Lines). `src/index.ts` is excluded from coverage; `src/example.ts`
+  is scaffolding.
+
+---
+
+## Commit Discipline (MANDATORY — NEVER SKIP)
+
+- **Commit small and often** — one logical unit = one commit. Never accumulate
+  more than ~5 changed files before committing.
+- `git status --short` must return **nothing** at session end. Never leave
+  uncommitted changes behind.
+- **Check state at every session start**: `git status --short`, `git branch`,
+  `git log --oneline -3`.
+
+### Pre-commit checklist (in order, no exceptions)
+
+1. **Update docs FIRST** — update [README.public.md](README.public.md),
+   [README.architecture.md](README.architecture.md), and this CLAUDE.md for any
+   API/behavior change **before** proposing a commit. A feature is NOT complete
+   until documentation matches.
+2. **Fix TypeScript/lint errors** in every touched file (use the IDE error checker).
+3. **`pnpm exec eslint <changed-files>`** to catch lint violations.
+4. **`pnpm test`** — must pass at 100% coverage. Fix all errors before moving on.
+
+### Golden files
+
+Behavior is pinned by golden snapshots in
+[test/goldens/example/converter/](test/goldens/example/converter/). When output
+changes intentionally, regenerate with `pnpm updateGoldens` and **review the
+diff** before committing — never regenerate blindly to make a test pass.
+
+### Version bump = separate commit
+
+```bash
+pnpm version patch --no-git-tag-version
+git commit -am"Increase version"
+```
+
+---
+
+## Full Ticket Workflow (exact order — complete all steps before the next ticket)
+
+```bash
+# 1. Start clean
+git checkout main && git fetch && git pull
+
+# 2. Feature branch (kebab-cased automatically)
+node scripts/create-branch.js "<description>"
+
+# 3. Update deps
+pnpm update --latest
+
+# 4. Develop, write tests, update docs
+
+# 5. Commit every ≤5-file logical unit
+git add . && git commit -am"<description>"
+
+# 6. Version bump
+pnpm version patch --no-git-tag-version && git commit -am"Increase version"
+
+# 7. Build (runs tests via prebuild)
+pnpm run build
+
+# 8. Rebase onto latest main
+git rebase main
+
+# 9. Push (refuses dirty tree; refuses push to main)
+node scripts/push-branch.js
+
+# 10. Create PR + auto-merge
+gh pr create --base main --title "<title>" --body " "
+gh pr merge --auto --squash
+
+# 11. Wait for merge
+node scripts/wait-for-pr.js
+
+# 12. Cleanup
+node scripts/delete-feature-branch.js
+```
+
+**`pnpm link` is acceptable during development for local cross-repo
+dependencies. Before PR/merge: remove all `pnpm.overrides` using `link:../...`
+and restore published versions of `@rljson/*` in `package.json` +
+`pnpm-lock.yaml`.**
+
+---
+
+## Git Scripts Reference
+
+| Script | Guard |
+|---|---|
+| `node scripts/create-branch.js "desc"` | Kebab-cases input; fails without a name |
+| `node scripts/push-branch.js` | Refuses dirty tree; refuses push to `main` |
+| `node scripts/wait-for-pr.js` | Polls until MERGED/CLOSED |
+| `node scripts/delete-feature-branch.js` | Requires clean tree + merged branch |
+| `node scripts/is-clean-repo.js` | Prints ✅/❌ |
+
+Never bypass these with raw git commands.
+
+---
+
+## Pre-existing Coverage Failures
+
+Pre-existing failures (in files NOT touched in this ticket) do not block a
+commit, but:
+- Prove pre-existing: `git stash && pnpm test; git stash pop`
+- Document in the commit message
+- Never add NEW failures in modified files
+
+---
+
+## Coverage Requirements
+
+- **All metrics MUST be 100%**: Statements, Branches, Functions, Lines
+  (enforced in [vitest.config.mts](vitest.config.mts)).
+- Coverage validates automatically in `pnpm test`. Build fails below 100%.
+- **Never** use `/* v8 ignore */` to avoid writing tests for reachable code.
+
+### Vitest 4.x semantic ignore hints (MANDATORY)
+
+All hints MUST include `-- @preserve` to survive esbuild transpilation.
+
+| Pattern | Meaning |
+|---|---|
+| `/* v8 ignore if -- @preserve */` | Ignore the if-branch |
+| `/* v8 ignore else -- @preserve */` | Ignore the else-branch |
+| `/* v8 ignore next -- @preserve */` | Ignore next statement/expression |
+| `/* v8 ignore file -- @preserve */` | Ignore entire file |
+| `/* v8 ignore start -- @preserve */` ... `/* v8 ignore stop -- @preserve */` | Ignore a range |
+
+**NEVER use:**
+
+```typescript
+/* v8 ignore next 3 -- @preserve */  // ❌ line-counting — fragile, breaks on refactoring
+/* v8 ignore next */                  // ❌ missing @preserve — esbuild strips the comment
+/* v8 ignore end */                   // ❌ 'end' not 'stop'
+```
+
+---
+
+## Package Manager & Tooling
+
+- Uses **pnpm**. **Never modify the `scripts` section in `package.json`** without
+  explicit user permission.
+- **ESM modules** (`"type": "module"`); Node `>=22.14.0`.
+- **ESLint 10** (`eslint@^10.4.0`) with `typescript-eslint@^8.x`. After
+  `pnpm update --latest`, run `pnpm exec eslint` to confirm the config still loads.
+- **License headers** required in all source files.
+- **Test framework**: Vitest with `describe()`, `it()`, `expect()`.
+
+---
+
+## Testing
+
+| Command | Purpose |
+|---|---|
+| `pnpm test` | All tests + coverage + lint |
+| `pnpm run build` | Full build (`prebuild` runs tests, then vite build + tsc + copy README) |
+| `pnpm updateGoldens` | Regenerate golden snapshot files |
+| Debug in VS Code | Open test file → set breakpoint → Alt+click play button in Test Explorer |
+
+---
+
+## Publish Workflow (MANDATORY)
+
+### Pre-publish checklist
+
+1. Remove all `pnpm.overrides` using `link:../...`; restore `package.json` +
+   `pnpm-lock.yaml` to published `@rljson/*` versions.
+2. `pnpm install` — reinstall with published versions.
+3. `pnpm test` — must pass at 100%.
+4. `pnpm run build`.
+5. `pnpm version patch --no-git-tag-version && git commit -am"Increase version"`.
+6. Commit ALL files including `package.json` and `pnpm-lock.yaml`.
+
+### Merge & publish
+
+Land the branch through the normal Ticket Workflow (PR + auto-merge), then from a
+clean `main`:
+
+```bash
+git checkout main && git pull
+node scripts/publish-to-npm.js   # guards: must be a clean main branch
+```
+
+`scripts/publish-to-npm.js` refuses to run on a dirty or non-`main` branch.
+Because the converter is downstream, publish it only **after** any upstream
+`@rljson/*` changes it depends on have been published and pulled in via
+`pnpm update --latest`.

--- a/README.public.md
+++ b/README.public.md
@@ -155,6 +155,85 @@ By default, the Converter will always generate Layers for nested components. Hen
 
 It is also possible to alias component properties. The definition of the Component `brand` consists of the property `manufacturer` within the input data objects. By defining `brand` as a destination, the converter aliases the property key to `brand` in the final components definition.
 
+##### Array Values (As-Is)
+
+When a component property points **directly** at an array in your source data,
+the array is taken over **verbatim** into the component. It is *not* decomposed
+into its own Type, Components and Layers — it is embedded as a single value, and
+its generated `TableCfg` column is typed `jsonArray`.
+
+Use this whenever you want to keep a list of values together as one opaque field
+(tags, labels, raw coordinates, a small embedded record list) and you do **not**
+need to normalize, deduplicate or reference its elements individually.
+
+###### Arrays of primitives
+
+```ts
+const json = {
+  id: 'car1',
+  tags: ['fast', 'red', 'electric'],
+};
+
+const chart: DecomposeChart = {
+  _sliceId: 'id',
+  tags: ['tags'],
+};
+
+const rljson = fromJson(json, chart);
+```
+
+The resulting `tags` component holds the array unchanged, and its column is
+typed `jsonArray`:
+
+```ts
+{
+  tags: {
+    _data: [{ tags: ['fast', 'red', 'electric'], _hash: '…' }],
+    _type: 'components',
+  },
+  // tableCfgs → tags column: { key: 'tags', type: 'jsonArray', … }
+}
+```
+
+###### Arrays of objects
+
+The same applies to arrays of objects. They are embedded as-is (each nested
+object is hashed in place by the Converter, but **no** separate `wheel`
+component/layer/sliceId table is created):
+
+```ts
+const json = {
+  id: 'car1',
+  wheels: [
+    { SN: 'BOB37382', brand: 'Borbet' },
+    { SN: 'BOB37383', brand: 'Michelin' },
+  ],
+};
+
+const chart: DecomposeChart = {
+  _sliceId: 'id',
+  wheels: ['wheels'],
+};
+```
+
+→ a single `wheels` component whose value is the array, with a `jsonArray`
+column.
+
+###### As-Is vs. Decomposition
+
+| Goal | Use |
+|---|---|
+| Keep the list together as one opaque field | **Array value (as-is)** — point a component property at the array key |
+| Normalize / deduplicate / reference elements individually, build a sub-cake and relations | **Sub-Types** — declare the array under `_types` with a `_path` (see *Component References* below) |
+
+###### Limitation — no traversal *into* arrays
+
+As-is handling resolves the array **at** the addressed path. A nested path that
+tries to reach *into* the array's elements (for example `wheels/brand`, hoping
+to collect every `brand`) is **not** supported on the normal path — there is no
+element-mapping or index syntax. If you need per-element fields, model the array
+as a Sub-Type via `_types` / `_path` instead.
+
 ##### Component References
 
 RLJSON provides the concept of hard-linked References, which means, that on any Components Object you can reference another Components Objects by suffixing the components Key by "Ref" and by providing its unique reference (Hash). Otherwise its possible to reference a sliceId of another Type by just suffixing the types Key by "SliceId".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rljson/converter",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "Convert flat textual data i. e. from JSON or XML into RLJSON data structure and data itself automatically.",
   "homepage": "https://github.com/rljson/converter",
   "bugs": "https://github.com/rljson/converter/issues",

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -388,6 +388,7 @@ const createComponentTableCfgs = (
   typeName?: string,
   chart?: DecomposeChart,
   nestedRljson?: Rljson,
+  data?: Array<Json>,
 ) => {
   if (Array.isArray(componentProperties)) {
     //Array of properties --> loop through properties and collect them as
@@ -432,6 +433,14 @@ const createComponentTableCfgs = (
         };
       }
 
+      // Resolve the actual value from the source data so a directly-addressed
+      // array property is typed `jsonArray` instead of the scalar default. The
+      // array is still embedded verbatim (not decomposed); only its column
+      // type is corrected. References keep their dedicated typing above.
+      const sample = ref
+        ? null
+        : nestedProperty(data![0], componentProperty, chart, nestedRljson);
+
       // Create column for each key in the propSkeleton
       const column = Object.entries(propSkeleton!).map(
         ([key, value]) =>
@@ -441,6 +450,8 @@ const createComponentTableCfgs = (
               ? ref.type == 'sliceIds'
                 ? 'jsonArray'
                 : 'string'
+              : Array.isArray((sample as any)?.[key])
+              ? 'jsonArray'
               : value,
             titleLong: key.charAt(0).toUpperCase() + key.slice(1),
             titleShort: key,
@@ -472,6 +483,7 @@ const createComponentTableCfgs = (
         typeName,
         chart,
         nestedRljson,
+        data,
       );
       nestedCompTableCfgs.push(...tableCfg);
     }
@@ -484,6 +496,7 @@ const createComponentTableCfgs = (
       typeName,
       chart![componentKey] as DecomposeChart,
       nestedRljson,
+      data,
     );
 
     return [...nestedCompTableCfgs, ...consolidatingTableCfg];
@@ -677,6 +690,7 @@ export const fromJson = (
         chart._name as string,
         chart,
         nestedRljson,
+        json,
       );
 
       //Add component TableCfgs and their history TableCfgs

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -34,13 +34,13 @@ import {
 
 import { traverse } from 'object-traversal';
 
-/* v8 ignore start */
+/* v8 ignore start -- @preserve */
 export class Converter {
   static get example(): Converter {
     return new Converter();
   }
 }
-/* v8 ignore end */
+/* v8 ignore stop -- @preserve */
 
 export type DecomposeChart = {
   _sliceId: string;

--- a/test/array-gap.spec.ts
+++ b/test/array-gap.spec.ts
@@ -1,0 +1,125 @@
+// @license
+// Copyright (c) 2025 Rljson
+//
+// Use of this source code is governed by terms that can be
+// found in the LICENSE file in the root of this package.
+
+import { BaseValidator, Validate } from '@rljson/rljson';
+
+import { describe, expect, it } from 'vitest';
+
+import { DecomposeChart, fromJson } from '../src/converter';
+
+const validate = async (rljson: any) => {
+  const v = new Validate();
+  v.addValidator(new BaseValidator());
+  return v.run(rljson);
+};
+
+// These tests surface the "array in source data" gap in the *normal*
+// (non-`_types`) processing path.
+//
+// Plain `it(...)` cases assert the CURRENT (broken) behavior, so they act as
+// change-detectors: a real fix will make them fail and force an update.
+//
+// `it.fails(...)` cases assert the DESIRED behavior; they currently throw, so
+// `.fails` keeps the suite green while documenting exactly what is missing.
+describe('Array gap (normal processing path)', () => {
+  // ── Case A: component pointed directly at an array ────────────────────────
+  // The whole array is embedded verbatim as a single component value, while
+  // the generated TableCfg column claims it is a scalar `string`. The mismatch
+  // is NOT caught by BaseValidator -> silent latent corruption.
+
+  it('A1: array of primitives is embedded with a wrong "string" column type', async () => {
+    const json = [{ id: 'car1', tags: ['fast', 'red', 'electric'] }];
+    const chart: DecomposeChart = { _sliceId: 'id', tags: ['tags'] };
+
+    const rljson = fromJson(json, chart) as any;
+
+    const row = rljson.tags._data[0];
+    const column = rljson.tableCfgs._data
+      .find((c: any) => c.key === 'tags')
+      .columns.find((c: any) => c.key === 'tags');
+
+    expect(row.tags).toEqual(['fast', 'red', 'electric']); // raw array embedded
+    expect(column.type).toBe('string'); // BUG: should be 'jsonArray' (or decomposed)
+    expect(await validate(rljson)).toStrictEqual({}); // BUG: corruption not caught
+  });
+
+  it('A2: array of objects is embedded (hashed blob), not decomposed', async () => {
+    const json = [
+      {
+        id: 'car1',
+        wheels: [
+          { SN: 'BOB37382', brand: 'Borbet' },
+          { SN: 'BOB37383', brand: 'Borbet' },
+        ],
+      },
+    ];
+    const chart: DecomposeChart = { _sliceId: 'id', wheels: ['wheels'] };
+
+    const rljson = fromJson(json, chart) as any;
+
+    const row = rljson.wheels._data[0];
+    const column = rljson.tableCfgs._data
+      .find((c: any) => c.key === 'wheels')
+      .columns.find((c: any) => c.key === 'wheels');
+
+    // Inner objects are hashed in place but stay embedded; no own table/layer.
+    expect(Array.isArray(row.wheels)).toBe(true);
+    expect(row.wheels[0]).toHaveProperty('_hash');
+    expect(rljson.wheel).toBeUndefined(); // no decomposed wheel table
+    expect(column.type).toBe('string'); // BUG: type/value mismatch
+    expect(await validate(rljson)).toStrictEqual({}); // BUG: corruption not caught
+  });
+
+  it.fails('A-desired: an array property should be decomposed or typed jsonArray', async () => {
+    const json = [{ id: 'car1', tags: ['fast', 'red'] }];
+    const chart: DecomposeChart = { _sliceId: 'id', tags: ['tags'] };
+
+    const rljson = fromJson(json, chart) as any;
+    const column = rljson.tableCfgs._data
+      .find((c: any) => c.key === 'tags')
+      .columns.find((c: any) => c.key === 'tags');
+
+    expect(column.type).toBe('jsonArray');
+  });
+
+  // ── Case B: nested path INTO an array ─────────────────────────────────────
+  // Traversal cannot index into an array, so the property resolves to null and
+  // is silently dropped, leaving an empty component object. No error, no signal.
+  // (Side finding: component tables are lower-cased, so `wheelBrand` ->
+  // `wheelbrand`.)
+
+  it('B: nested path into an array silently drops the data', async () => {
+    const json = [
+      {
+        id: 'car1',
+        wheels: [
+          { SN: 'BOB37382', brand: 'Borbet' },
+          { SN: 'BOB37383', brand: 'Michelin' },
+        ],
+      },
+    ];
+    const chart: DecomposeChart = { _sliceId: 'id', wheelBrand: ['wheels/brand'] };
+
+    const rljson = fromJson(json, chart) as any;
+
+    // Table name is lower-cased; the row is an empty object (data lost).
+    const row = rljson.wheelbrand._data[0];
+    expect(Object.keys(row)).toEqual(['_hash']); // only the hash, no `brand`
+    expect(row.brand).toBeUndefined(); // silent data loss
+  });
+
+  it.fails('B-desired: a nested-into-array path should carry the inner values', async () => {
+    const json = [
+      { id: 'car1', wheels: [{ brand: 'Borbet' }, { brand: 'Michelin' }] },
+    ];
+    const chart: DecomposeChart = { _sliceId: 'id', wheelBrand: ['wheels/brand'] };
+
+    const rljson = fromJson(json, chart) as any;
+    const row = rljson.wheelbrand._data[0];
+
+    expect(row.brand).toEqual(['Borbet', 'Michelin']);
+  });
+});

--- a/test/array-gap.spec.ts
+++ b/test/array-gap.spec.ts
@@ -16,21 +16,16 @@ const validate = async (rljson: any) => {
   return v.run(rljson);
 };
 
-// These tests surface the "array in source data" gap in the *normal*
-// (non-`_types`) processing path.
-//
-// Plain `it(...)` cases assert the CURRENT (broken) behavior, so they act as
-// change-detectors: a real fix will make them fail and force an update.
-//
-// `it.fails(...)` cases assert the DESIRED behavior; they currently throw, so
-// `.fails` keeps the suite green while documenting exactly what is missing.
-describe('Array gap (normal processing path)', () => {
+// Behavior of arrays in source data on the *normal* (non-`_types`) processing
+// path. A directly-addressed array property is embedded verbatim (NOT
+// decomposed) and is now typed `jsonArray` in its TableCfg column. A path that
+// tries to reach *into* an array is still unsupported (out of scope).
+describe('Array in normal processing path', () => {
   // ── Case A: component pointed directly at an array ────────────────────────
-  // The whole array is embedded verbatim as a single component value, while
-  // the generated TableCfg column claims it is a scalar `string`. The mismatch
-  // is NOT caught by BaseValidator -> silent latent corruption.
+  // The whole array is embedded as a single component value; the generated
+  // column type is `jsonArray` so the RLJSON is internally consistent.
 
-  it('A1: array of primitives is embedded with a wrong "string" column type', async () => {
+  it('A1: array of primitives is embedded and typed jsonArray', async () => {
     const json = [{ id: 'car1', tags: ['fast', 'red', 'electric'] }];
     const chart: DecomposeChart = { _sliceId: 'id', tags: ['tags'] };
 
@@ -41,12 +36,12 @@ describe('Array gap (normal processing path)', () => {
       .find((c: any) => c.key === 'tags')
       .columns.find((c: any) => c.key === 'tags');
 
-    expect(row.tags).toEqual(['fast', 'red', 'electric']); // raw array embedded
-    expect(column.type).toBe('string'); // BUG: should be 'jsonArray' (or decomposed)
-    expect(await validate(rljson)).toStrictEqual({}); // BUG: corruption not caught
+    expect(row.tags).toEqual(['fast', 'red', 'electric']); // embedded, not decomposed
+    expect(column.type).toBe('jsonArray'); // correct type (was wrongly 'string')
+    expect(await validate(rljson)).toStrictEqual({});
   });
 
-  it('A2: array of objects is embedded (hashed blob), not decomposed', async () => {
+  it('A2: array of objects is embedded (hashed blob) and typed jsonArray', async () => {
     const json = [
       {
         id: 'car1',
@@ -65,29 +60,38 @@ describe('Array gap (normal processing path)', () => {
       .find((c: any) => c.key === 'wheels')
       .columns.find((c: any) => c.key === 'wheels');
 
-    // Inner objects are hashed in place but stay embedded; no own table/layer.
     expect(Array.isArray(row.wheels)).toBe(true);
-    expect(row.wheels[0]).toHaveProperty('_hash');
-    expect(rljson.wheel).toBeUndefined(); // no decomposed wheel table
-    expect(column.type).toBe('string'); // BUG: type/value mismatch
-    expect(await validate(rljson)).toStrictEqual({}); // BUG: corruption not caught
+    expect(row.wheels[0]).toHaveProperty('_hash'); // embedded, not its own table
+    expect(rljson.wheel).toBeUndefined(); // not decomposed into a wheel table
+    expect(column.type).toBe('jsonArray');
+    expect(await validate(rljson)).toStrictEqual({});
   });
 
-  it.fails('A-desired: an array property should be decomposed or typed jsonArray', async () => {
-    const json = [{ id: 'car1', tags: ['fast', 'red'] }];
-    const chart: DecomposeChart = { _sliceId: 'id', tags: ['tags'] };
+  it('A3: a property absent from the source is typed as scalar (no crash)', async () => {
+    // `notes` is declared in the chart but missing in the data; the value
+    // resolves to null, so the column falls back to the scalar default rather
+    // than throwing while building the TableCfg.
+    const json = [{ id: 'car1', tags: ['fast'] }];
+    const chart: DecomposeChart = {
+      _sliceId: 'id',
+      tags: ['tags'],
+      notes: ['notes'],
+    };
 
     const rljson = fromJson(json, chart) as any;
-    const column = rljson.tableCfgs._data
-      .find((c: any) => c.key === 'tags')
-      .columns.find((c: any) => c.key === 'tags');
 
-    expect(column.type).toBe('jsonArray');
+    const notesColumn = rljson.tableCfgs._data
+      .find((c: any) => c.key === 'notes')
+      .columns.find((c: any) => c.key === 'notes');
+
+    expect(notesColumn.type).toBe('string'); // scalar default, not jsonArray
+    expect(await validate(rljson)).toStrictEqual({});
   });
 
-  // ── Case B: nested path INTO an array ─────────────────────────────────────
+  // ── Case B: nested path INTO an array (out of scope) ──────────────────────
   // Traversal cannot index into an array, so the property resolves to null and
-  // is silently dropped, leaving an empty component object. No error, no signal.
+  // is silently dropped, leaving an empty component object. This remains
+  // unsupported by design — arrays of objects belong in `_types`.
   // (Side finding: component tables are lower-cased, so `wheelBrand` ->
   // `wheelbrand`.)
 
@@ -105,7 +109,6 @@ describe('Array gap (normal processing path)', () => {
 
     const rljson = fromJson(json, chart) as any;
 
-    // Table name is lower-cased; the row is an empty object (data lost).
     const row = rljson.wheelbrand._data[0];
     expect(Object.keys(row)).toEqual(['_hash']); // only the hash, no `brand`
     expect(row.brand).toBeUndefined(); // silent data loss

--- a/test/converter.spec.ts
+++ b/test/converter.spec.ts
@@ -799,6 +799,55 @@ describe('From JSON', () => {
     expect(result).toStrictEqual({});
   });
 
+  it('Array-valued properties are embedded as-is and typed jsonArray.', async () => {
+    // Arrays addressed directly through a normal-path component are embedded
+    // verbatim (NOT decomposed) and their TableCfg column is typed `jsonArray`.
+    // Both arrays of primitives (`tags`) and arrays of objects (`wheels`) are
+    // supported this way.
+    const json = [
+      {
+        id: 'car1',
+        tags: ['fast', 'red'],
+        wheels: [
+          { SN: 'BOB37382', brand: 'Borbet' },
+          { SN: 'BOB37383', brand: 'Michelin' },
+        ],
+      },
+      {
+        id: 'car2',
+        tags: ['eco'],
+        wheels: [{ SN: 'BOB37384', brand: 'Borbet' }],
+      },
+    ];
+
+    const chart: DecomposeChart = {
+      _sliceId: 'id',
+      tags: ['tags'],
+      wheels: ['wheels'],
+    };
+
+    const rljson = fromJson(json, chart);
+
+    // The arrays are embedded unchanged in their components.
+    expect((rljson as any).tags._data[0].tags).toEqual(['fast', 'red']);
+    expect((rljson as any).wheels._data[0].wheels).toHaveLength(2);
+
+    // Both component columns are typed `jsonArray`.
+    const columnType = (table: string) =>
+      (rljson as any).tableCfgs._data
+        .find((c: any) => c.key === table)
+        .columns.find((c: any) => c.key === table).type;
+    expect(columnType('tags')).toBe('jsonArray');
+    expect(columnType('wheels')).toBe('jsonArray');
+
+    const v = new Validate();
+    v.addValidator(new BaseValidator());
+    const result = await v.run(rljson);
+
+    await expectGolden('example/converter/array-as-is.json').toBe(rljson);
+    expect(result).toStrictEqual({});
+  });
+
   it('Basic object with nested sliceId should convert without Error.', async () => {
     const json = {
       meta: { id: 'car1' },

--- a/test/goldens/example/converter/array-as-is.json
+++ b/test/goldens/example/converter/array-as-is.json
@@ -1,0 +1,934 @@
+{
+  "sliceId": {
+    "_type": "sliceIds",
+    "_data": [
+      {
+        "add": [
+          "car1",
+          "car2"
+        ],
+        "_hash": "_nk8S8AyHcfQkgZB4h7np7"
+      }
+    ],
+    "_hash": "NARVzXpEumhJlMK8UKtEtQ",
+    "tableCfg": "RZTg2Ienhp2gd_mjN4CE0u"
+  },
+  "tags": {
+    "_data": [
+      {
+        "tags": [
+          "fast",
+          "red"
+        ],
+        "_hash": "Np1XUnfYu4L-O7xG_O-fW0"
+      },
+      {
+        "tags": [
+          "eco"
+        ],
+        "_hash": "l72vJsxDZmm18DVZ6u-crm"
+      }
+    ],
+    "_type": "components",
+    "_hash": "Tlfsj6zJpBMCGCW0J6BKtd",
+    "tableCfg": "uJJMmICHEdylrg9RbUBwFS"
+  },
+  "wheels": {
+    "_data": [
+      {
+        "wheels": [
+          {
+            "SN": "BOB37382",
+            "brand": "Borbet",
+            "_hash": "D5-qTLvJPaIe6gv9Rvqdp8"
+          },
+          {
+            "SN": "BOB37383",
+            "brand": "Michelin",
+            "_hash": "0LBlpnTkzg_ldtEabVPsVi"
+          }
+        ],
+        "_hash": "HZn_TPcKnRn3PwRx_C7VD4"
+      },
+      {
+        "wheels": [
+          {
+            "SN": "BOB37384",
+            "brand": "Borbet",
+            "_hash": "dB2UbsPdODqv3EEVK4vhOj"
+          }
+        ],
+        "_hash": "-95-SGGFZHVqEYhs1vOnd7"
+      }
+    ],
+    "_type": "components",
+    "_hash": "_2m0seK25SFGRAq4FMCWPx",
+    "tableCfg": "hM38hRmDpmwibPOdwVPaVs"
+  },
+  "tagsLayer": {
+    "_type": "layers",
+    "_data": [
+      {
+        "add": {
+          "car1": "Np1XUnfYu4L-O7xG_O-fW0",
+          "car2": "l72vJsxDZmm18DVZ6u-crm",
+          "_hash": "njnn_fGvbhsYIh591bj-6w"
+        },
+        "sliceIdsTable": "sliceId",
+        "sliceIdsTableRow": "_nk8S8AyHcfQkgZB4h7np7",
+        "componentsTable": "tags",
+        "_hash": "dez0_mgumV0vIWXSpaP_ln"
+      }
+    ],
+    "_hash": "sPv6VOZ4FzVzV_BWmQNSxK",
+    "tableCfg": "Lh_-T3BIYdbEzHOUzs9l5L"
+  },
+  "wheelsLayer": {
+    "_type": "layers",
+    "_data": [
+      {
+        "add": {
+          "car1": "HZn_TPcKnRn3PwRx_C7VD4",
+          "car2": "-95-SGGFZHVqEYhs1vOnd7",
+          "_hash": "7j1mV5nA_o1ZTVAGo5xxQf"
+        },
+        "sliceIdsTable": "sliceId",
+        "sliceIdsTableRow": "_nk8S8AyHcfQkgZB4h7np7",
+        "componentsTable": "wheels",
+        "_hash": "8oghjXgdO4YYqV33Oa09q5"
+      }
+    ],
+    "_hash": "ij3SfRIK2yWG8dePGuRkfX",
+    "tableCfg": "UkmwgKh5O-q27HgauBkRaF"
+  },
+  "tagsInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "u-c4wuOQzIwx_0H_9jHipT",
+    "_hash": "aGBc3LhVYNkFOz37vBGB8W"
+  },
+  "wheelsInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "LhcN6V3NVPmYgHhPUd86nx",
+    "_hash": "JrJ3qocSYXMRA-OZWUNENJ"
+  },
+  "tagsLayerInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "qiXCd0sAkeIH5_HTNxmhfD",
+    "_hash": "ikeQeVXu89WZXW82kxWw9P"
+  },
+  "wheelsLayerInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "J_HmK2VH_nZgD303r0VjIg",
+    "_hash": "ofyH4xEf4THv_apgQItBl0"
+  },
+  "cakeInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "3cOCcAAB65wojrC2nJw_Ds",
+    "_hash": "V14Z63DbIewIFOZjrLe_FX"
+  },
+  "sliceIdInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "fHMgHWYdgp_MgMqDdxAwdd",
+    "_hash": "xYBP945uISG107mSux8wkC"
+  },
+  "cakeEdits": {
+    "_type": "edits",
+    "_data": [],
+    "_hash": "DUkCwD5MSuDs4-ROLby9GQ",
+    "tableCfg": "qlQS3VXDBK7_LCa-R5LPp4"
+  },
+  "cakeMultiEdits": {
+    "_type": "multiEdits",
+    "_data": [],
+    "_hash": "7E_pqNxZX1XPs9pZ494xEX",
+    "tableCfg": "6fkO0tDtVngSTsMYAzDpZ6"
+  },
+  "cakeEditHistory": {
+    "_type": "editHistory",
+    "_data": [],
+    "_hash": "YAQqZvDJq990ASR1jcSoTy",
+    "tableCfg": "br6Gh7cYwZ-BzuTIvvIdrG"
+  },
+  "cake": {
+    "_type": "cakes",
+    "_data": [
+      {
+        "sliceIdsTable": "sliceId",
+        "sliceIdsRow": "_nk8S8AyHcfQkgZB4h7np7",
+        "layers": {
+          "tagsLayer": "dez0_mgumV0vIWXSpaP_ln",
+          "wheelsLayer": "8oghjXgdO4YYqV33Oa09q5",
+          "_hash": "rVJWJv_MahmBLY3t0Hvifl"
+        },
+        "_hash": "GFsNgU5mgY5oSDlpUUt6KT"
+      }
+    ],
+    "tableCfg": "LNnUkPxIRwOGWTu6_mzDpx",
+    "_hash": "hFPz6Ji1OaoQ5kPeQGefHL"
+  },
+  "tableCfgs": {
+    "_type": "tableCfgs",
+    "_data": [
+      {
+        "key": "tagsLayer",
+        "type": "layers",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "base",
+            "type": "string",
+            "titleLong": "Base",
+            "titleShort": "Base",
+            "_hash": "EfTZIQZC5xpkbx3LcIDhlS"
+          },
+          {
+            "key": "sliceIdsTable",
+            "type": "string",
+            "titleLong": "Slice Ids Table",
+            "titleShort": "Slice Ids Table",
+            "_hash": "1k77uzMUkjc7tCJlGN31GI"
+          },
+          {
+            "key": "sliceIdsTableRow",
+            "type": "string",
+            "titleLong": "Slice Ids Table Row",
+            "titleShort": "Slice Ids Table Row",
+            "_hash": "b7tMAXjYmRs96pxCcwt812"
+          },
+          {
+            "key": "componentsTable",
+            "type": "string",
+            "titleLong": "Components Table",
+            "titleShort": "Components Table",
+            "_hash": "8oL-bX7Ty76VQFzuIWBrdg"
+          },
+          {
+            "key": "add",
+            "type": "json",
+            "titleLong": "Add",
+            "titleShort": "Add",
+            "_hash": "FZN1kwlNoq9Cv6qIWvNg-3"
+          },
+          {
+            "key": "remove",
+            "type": "json",
+            "titleLong": "Remove",
+            "titleShort": "Remove",
+            "_hash": "UXIjvdKRUxEq3KTXudtaon"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "Lh_-T3BIYdbEzHOUzs9l5L"
+      },
+      {
+        "key": "tagsLayerInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "tagsLayerRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "tagsLayerMultiEdits",
+              "type": "layers",
+              "_hash": "AhGkmHQDYxkwCAvSNyHHcB"
+            },
+            "_hash": "n5xGCgcN2jeE2Xqx1OTo6G"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "qiXCd0sAkeIH5_HTNxmhfD"
+      },
+      {
+        "key": "wheelsLayer",
+        "type": "layers",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "base",
+            "type": "string",
+            "titleLong": "Base",
+            "titleShort": "Base",
+            "_hash": "EfTZIQZC5xpkbx3LcIDhlS"
+          },
+          {
+            "key": "sliceIdsTable",
+            "type": "string",
+            "titleLong": "Slice Ids Table",
+            "titleShort": "Slice Ids Table",
+            "_hash": "1k77uzMUkjc7tCJlGN31GI"
+          },
+          {
+            "key": "sliceIdsTableRow",
+            "type": "string",
+            "titleLong": "Slice Ids Table Row",
+            "titleShort": "Slice Ids Table Row",
+            "_hash": "b7tMAXjYmRs96pxCcwt812"
+          },
+          {
+            "key": "componentsTable",
+            "type": "string",
+            "titleLong": "Components Table",
+            "titleShort": "Components Table",
+            "_hash": "8oL-bX7Ty76VQFzuIWBrdg"
+          },
+          {
+            "key": "add",
+            "type": "json",
+            "titleLong": "Add",
+            "titleShort": "Add",
+            "_hash": "FZN1kwlNoq9Cv6qIWvNg-3"
+          },
+          {
+            "key": "remove",
+            "type": "json",
+            "titleLong": "Remove",
+            "titleShort": "Remove",
+            "_hash": "UXIjvdKRUxEq3KTXudtaon"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "UkmwgKh5O-q27HgauBkRaF"
+      },
+      {
+        "key": "wheelsLayerInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "wheelsLayerRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "wheelsLayerMultiEdits",
+              "type": "layers",
+              "_hash": "v62XY0sk64LoV2nmUIysD4"
+            },
+            "_hash": "Ev9On8y2W6tov68jZ0C8kU"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "J_HmK2VH_nZgD303r0VjIg"
+      },
+      {
+        "key": "tags",
+        "type": "components",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "tags",
+            "type": "jsonArray",
+            "titleLong": "Tags",
+            "titleShort": "tags",
+            "_hash": "k2A059r8TfivczP-OY58ff"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "uJJMmICHEdylrg9RbUBwFS"
+      },
+      {
+        "key": "tagsInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "tagsRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "tagsMultiEdits",
+              "type": "components",
+              "_hash": "sjB1LU1htNCV2ZwHVa4b-h"
+            },
+            "_hash": "SiPGji3dR4avfA7IcQg_sh"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "u-c4wuOQzIwx_0H_9jHipT"
+      },
+      {
+        "key": "wheels",
+        "type": "components",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "wheels",
+            "type": "jsonArray",
+            "titleLong": "Wheels",
+            "titleShort": "wheels",
+            "_hash": "A80pdYboF8iDrls52a2grT"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "hM38hRmDpmwibPOdwVPaVs"
+      },
+      {
+        "key": "wheelsInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "wheelsRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "wheelsMultiEdits",
+              "type": "components",
+              "_hash": "Vb3TXnWyfM9zwhkwZaRpOc"
+            },
+            "_hash": "R3BSZaVD_OqXVhu7KtfoCU"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "LhcN6V3NVPmYgHhPUd86nx"
+      },
+      {
+        "key": "cake",
+        "type": "cakes",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "sliceIdsTable",
+            "type": "string",
+            "titleLong": "Slice Ids Table",
+            "titleShort": "Slice Ids Table",
+            "_hash": "1k77uzMUkjc7tCJlGN31GI"
+          },
+          {
+            "key": "sliceIdsRow",
+            "type": "string",
+            "titleLong": "Slice Ids Row",
+            "titleShort": "Slice Ids Row",
+            "_hash": "T3yH4vS0oUYRZAFPq0eIkc"
+          },
+          {
+            "key": "layers",
+            "type": "json",
+            "titleLong": "Layers",
+            "titleShort": "Layers",
+            "_hash": "DpUNHLADN7AoClIh7IjdUE"
+          },
+          {
+            "key": "id",
+            "type": "string",
+            "titleLong": "ID",
+            "titleShort": "ID",
+            "_hash": "UmazCpc_m0Ww4a9TQd1MpY"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "LNnUkPxIRwOGWTu6_mzDpx"
+      },
+      {
+        "key": "cakeInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "cakeRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "cakeMultiEdits",
+              "type": "cakes",
+              "_hash": "FuA7gf7rbIS95e35mlQsFt"
+            },
+            "_hash": "vsOnsbqGa4Dvvc25UcaReG"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "3cOCcAAB65wojrC2nJw_Ds"
+      },
+      {
+        "key": "cakeEdits",
+        "type": "edits",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "name",
+            "type": "string",
+            "titleLong": "Name of the Edit",
+            "titleShort": "Name",
+            "_hash": "68dYimY7OxSjVma_WbDdt1"
+          },
+          {
+            "key": "action",
+            "type": "json",
+            "titleLong": "Edit Action Data",
+            "titleShort": "Action",
+            "_hash": "Y_wME1LxPftQx6olWB1AHg"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "qlQS3VXDBK7_LCa-R5LPp4"
+      },
+      {
+        "key": "cakeMultiEdits",
+        "type": "multiEdits",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "previous",
+            "type": "string",
+            "titleLong": "Previous Value",
+            "titleShort": "Previous",
+            "_hash": "OApUMVg0XzxL4rAp8-vHH3"
+          },
+          {
+            "key": "edit",
+            "type": "string",
+            "titleLong": "Edit Reference",
+            "titleShort": "Edit Ref",
+            "ref": {
+              "tableKey": "cakeEdits",
+              "_hash": "7DqJyCOsez_u5WDOPWZiPd"
+            },
+            "_hash": "ArNSHhLJ9wtZFzwwCuRKj6"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "6fkO0tDtVngSTsMYAzDpZ6"
+      },
+      {
+        "key": "cakeEditHistory",
+        "type": "editHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time Identifier",
+            "titleShort": "Time ID",
+            "_hash": "2ej3dpJSAPgLtZjcQ1zj8C"
+          },
+          {
+            "key": "multiEditRef",
+            "type": "string",
+            "titleLong": "Multi Edit Reference",
+            "titleShort": "Multi Edit Ref",
+            "ref": {
+              "tableKey": "cakeMultiEdits",
+              "_hash": "7K3KFmWk8xtz7GY9IfcoPm"
+            },
+            "_hash": "ksTfdipU0D-kyevi4ChnDw"
+          },
+          {
+            "key": "dataRef",
+            "type": "string",
+            "titleLong": "Data Reference",
+            "titleShort": "Data Ref",
+            "ref": {
+              "tableKey": "cake",
+              "_hash": "8v6-ycZSHstBxihNr5imft"
+            },
+            "_hash": "QtI62bWfhZtg5qlLsghYPv"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous Values",
+            "titleShort": "Previous",
+            "_hash": "7M8j7b_kcQ6SsWVzcs62fr"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "br6Gh7cYwZ-BzuTIvvIdrG"
+      },
+      {
+        "key": "sliceId",
+        "type": "sliceIds",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "base",
+            "type": "string",
+            "titleLong": "Base Slice ID",
+            "titleShort": "Base",
+            "_hash": "o9xR4pvOiAH_Pa2DKOsdTW"
+          },
+          {
+            "key": "add",
+            "type": "jsonArray",
+            "titleLong": "Slice IDs",
+            "titleShort": "IDs",
+            "_hash": "_fblsOPzjZqKHBArTgBNfR"
+          },
+          {
+            "key": "remove",
+            "type": "jsonArray",
+            "titleLong": "Removed Slice IDs",
+            "titleShort": "Removed",
+            "_hash": "2gv0UnQ6-BRjZJ3lsdzvZ1"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "RZTg2Ienhp2gd_mjN4CE0u"
+      },
+      {
+        "key": "sliceIdInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "sliceIdRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "sliceIdMultiEdits",
+              "type": "sliceIds",
+              "_hash": "kC_foemDUPdsEOkDitGpFX"
+            },
+            "_hash": "163-SDrrAqEpi-X47m4_vt"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "fHMgHWYdgp_MgMqDdxAwdd"
+      }
+    ],
+    "_hash": "D7UjnEeey_kCdzTVB6JEcJ"
+  },
+  "_hash": "BF_0T7GxKZSsA6nn5E2S3K"
+}


### PR DESCRIPTION
## Summary
- Type directly-addressed array properties as `jsonArray` (embedded as-is, not decomposed) on the normal processing path
- Restore coverage measurement of `converter.ts` (broken `v8 ignore end` → `stop`); file now measures 100%
- Add golden-backed array test + behavioral specs
- Document "Array Values (As-Is)" in README.public.md
- Add CLAUDE.md (branch/merge/publish workflow + conventions)

## Tests
26 passed, 1 expected-fail (documents an intentionally-unsupported nested-into-array path); 100% coverage (267 stmts / 116 branches / 32 funcs); lint clean. No existing golden changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)