### PR TITLE
Support composite sliceIds via array-valued _sliceId

### DIFF
--- a/README.public.md
+++ b/README.public.md
@@ -75,6 +75,38 @@ Nested `_sliceId` paths work for the main chart as well as for sub-types in
 before, so this is fully backwards compatible — a nested `_sliceId` produces the
 identical RLJSON to a flat one pointing at the same resolved value.
 
+#### Composite SliceId
+
+If no single field is unique on its own, `_sliceId` may be an **array of
+paths** instead of a single path. Each path is resolved independently
+(nested `/` paths are supported per entry), and the resolved values are
+combined into one deterministic sliceId:
+
+```ts
+const json = [
+  { make: 'Volkswagen', model: 'Polo', doors: 5 },
+  { make: 'Volkswagen', model: 'Golf', doors: 3 },
+];
+
+const chart: DecomposeChart = {
+  _sliceId: ['make', 'model'], // 'make' alone is not unique here
+  general: ['doors'],
+};
+```
+
+Values are combined by hashing the resolved `{path: value}` record rather
+than joining them into a string. This avoids collisions between items whose
+field values themselves contain a separator character (e.g. `make: 'A/B'`
++ `model: 'C'` colliding with `make: 'A'` + `model: 'B/C'` under a naive
+join). Composite `_sliceId` works anywhere a single `_sliceId` does — the
+main chart, sub-types declared via `_types`, and `sliceId@Type` reference
+embedding.
+
+If any one of the declared fields doesn't resolve for a given item, the
+whole composite key is treated as unresolved for that item and the
+[SliceId Fallback](#sliceid-fallback) content-hash applies, exactly like an
+unresolved single-path `_sliceId`.
+
 #### SliceId Fallback
 
 Real-world data doesn't always have a natural, already-unique field to use as

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rljson/converter",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "Convert flat textual data i. e. from JSON or XML into RLJSON data structure and data itself automatically.",
   "homepage": "https://github.com/rljson/converter",
   "bugs": "https://github.com/rljson/converter/issues",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "read-pkg": "^10.1.0",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.63.0",
-    "vite": "^8.1.3",
+    "vite": "^8.1.4",
     "vite-node": "^6.0.0",
     "vite-plugin-dts": "^5.0.3",
     "vite-tsconfig-paths": "^6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,20 +61,20 @@ importers:
         specifier: ^8.63.0
         version: 8.63.0(eslint@10.6.0)(typescript@6.0.3)
       vite:
-        specifier: ^8.1.3
-        version: 8.1.3(@types/node@26.1.1)(esbuild@0.27.2)
+        specifier: ^8.1.4
+        version: 8.1.4(@types/node@26.1.1)(esbuild@0.27.2)
       vite-node:
         specifier: ^6.0.0
         version: 6.0.0(@types/node@26.1.1)(esbuild@0.27.2)
       vite-plugin-dts:
         specifier: ^5.0.3
-        version: 5.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.1.1))(esbuild@0.27.2)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2))
+        version: 5.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.1.1))(esbuild@0.27.2)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2))
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2))
+        version: 6.1.1(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2))
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2))
       vitest-dom:
         specifier: ^0.1.1
         version: 0.1.1(vitest@4.1.10)
@@ -371,8 +371,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/types@0.138.0':
-    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@rljson/hash@0.0.19':
     resolution: {integrity: sha512-1bBHWbzzaOE3ba2niyvmu4d9VYv5atLzzHDI2ka3AlHLyBDD8Q9qI/HCjimULJlprIGVeN4+jN8sth4CdnGxOQ==}
@@ -386,91 +386,91 @@ packages:
     resolution: {integrity: sha512-wh3l1fGVukXjzF1SY7BMT0h7zbvBhAuGZDnFIOGpDIYDYeJKJF+T9mehUVnodZqrhBs/t4fmFCAdC3OJtonJ+w==}
     engines: {node: '>=22.14.0'}
 
-  '@rolldown/binding-android-arm64@1.1.4':
-    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.4':
-    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.4':
-    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.4':
-    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
-    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.4':
-    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.4':
-    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
-    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.4':
-    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.4':
-    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.1.4':
-    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.1.4':
-    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.4':
-    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.4':
-    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.4':
-    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1363,8 +1363,8 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rolldown@1.1.4:
-    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1601,8 +1601,8 @@ packages:
     peerDependencies:
       vite: '*'
 
-  vite@8.1.3:
-    resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1959,7 +1959,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@oxc-project/types@0.138.0': {}
+  '@oxc-project/types@0.139.0': {}
 
   '@rljson/hash@0.0.19':
     dependencies:
@@ -1973,53 +1973,53 @@ snapshots:
       '@rljson/json': 0.0.23
       nanoid: 5.1.16
 
-  '@rolldown/binding-android-arm64@1.1.4':
+  '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.4':
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.4':
+  '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.4':
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.4':
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.4':
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.4':
+  '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.4':
+  '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.4':
+  '@rolldown/binding-wasm32-wasi@1.1.5':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.4':
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -2268,7 +2268,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -2279,13 +2279,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2))':
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.3(@types/node@26.1.1)(esbuild@0.27.2)
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.2)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -2968,26 +2968,26 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rolldown@1.1.4:
+  rolldown@1.1.5:
     dependencies:
-      '@oxc-project/types': 0.138.0
+      '@oxc-project/types': 0.139.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.4
-      '@rolldown/binding-darwin-arm64': 1.1.4
-      '@rolldown/binding-darwin-x64': 1.1.4
-      '@rolldown/binding-freebsd-x64': 1.1.4
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
-      '@rolldown/binding-linux-arm64-gnu': 1.1.4
-      '@rolldown/binding-linux-arm64-musl': 1.1.4
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
-      '@rolldown/binding-linux-s390x-gnu': 1.1.4
-      '@rolldown/binding-linux-x64-gnu': 1.1.4
-      '@rolldown/binding-linux-x64-musl': 1.1.4
-      '@rolldown/binding-openharmony-arm64': 1.1.4
-      '@rolldown/binding-wasm32-wasi': 1.1.4
-      '@rolldown/binding-win32-arm64-msvc': 1.1.4
-      '@rolldown/binding-win32-x64-msvc': 1.1.4
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   semver@7.7.4:
     optional: true
@@ -3119,7 +3119,7 @@ snapshots:
   universalify@2.0.1:
     optional: true
 
-  unplugin-dts@1.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.1.1))(esbuild@0.27.2)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2)):
+  unplugin-dts@1.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.1.1))(esbuild@0.27.2)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2)):
     dependencies:
       '@rollup/pluginutils': 5.4.0
       '@volar/typescript': 2.4.28
@@ -3133,8 +3133,8 @@ snapshots:
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.9(@types/node@26.1.1)
       esbuild: 0.27.2
-      rolldown: 1.1.4
-      vite: 8.1.3(@types/node@26.1.1)(esbuild@0.27.2)
+      rolldown: 1.1.5
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3160,7 +3160,7 @@ snapshots:
       es-module-lexer: 2.3.0
       obug: 2.1.3
       pathe: 2.0.3
-      vite: 8.1.3(@types/node@26.1.1)(esbuild@0.27.2)
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.2)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -3175,12 +3175,12 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.1.1))(esbuild@0.27.2)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2)):
+  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.1.1))(esbuild@0.27.2)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2)):
     dependencies:
-      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.1.1))(esbuild@0.27.2)(rolldown@1.1.4)(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2))
+      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.1.1))(esbuild@0.27.2)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2))
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.9(@types/node@26.1.1)
-      vite: 8.1.3(@types/node@26.1.1)(esbuild@0.27.2)
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/language-core'
@@ -3190,22 +3190,22 @@ snapshots:
       - typescript
       - webpack
 
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2)):
+  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 8.1.3(@types/node@26.1.1)(esbuild@0.27.2)
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2):
+  vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
       postcss: 8.5.16
-      rolldown: 1.1.4
+      rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.1.1
@@ -3220,12 +3220,12 @@ snapshots:
       dom-accessibility-api: 0.6.3
       lodash-es: 4.18.1
       redent: 4.0.0
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2))
 
-  vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2)):
+  vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.1)(esbuild@0.27.2))
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.2))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -3242,7 +3242,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@26.1.1)(esbuild@0.27.2)
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -43,7 +43,7 @@ export class Converter {
 /* v8 ignore stop -- @preserve */
 
 export type DecomposeChart = {
-  _sliceId?: string;
+  _sliceId?: string | string[];
   _name?: string;
   _path?: string;
   _types?: DecomposeChart[];
@@ -117,14 +117,37 @@ const resolveSliceId = (
   return current as JsonBasicValueType | undefined;
 };
 
+// Resolves a composite sliceId from multiple field paths, combining the
+// resolved values into a single deterministic hash. Hashing (rather than
+// e.g. delimiter-joining) avoids collisions between items whose field values
+// themselves contain a separator character. If any of the paths does not
+// resolve, returns undefined so the caller can fall back like a single
+// unresolved _sliceId path would.
+const resolveCompositeSliceId = (
+  item: Json,
+  paths: string[],
+): JsonBasicValueType | undefined => {
+  const values: Json = {};
+  for (const path of paths) {
+    const value = resolveSliceId(item, path);
+    if (value === undefined || value === null) return undefined;
+    values[path] = value as JsonBasicValueType;
+  }
+  return hsh(values)._hash as JsonBasicValueType;
+};
+
 // Falls back to a content hash of the item when no _sliceId path is
-// declared, or the declared path does not resolve for this item — this
+// declared, or the declared path(s) do not resolve for this item — this
 // gives every item a stable identity even without a natural key.
 const resolveSliceIdWithFallback = (
   item: Json,
-  path: string | undefined,
+  path: string | string[] | undefined,
 ): JsonBasicValueType => {
-  const resolved = path ? resolveSliceId(item, path) : undefined;
+  const resolved = path
+    ? Array.isArray(path)
+      ? resolveCompositeSliceId(item, path)
+      : resolveSliceId(item, path)
+    : undefined;
   if (resolved !== undefined && resolved !== null) return resolved;
   return hsh(item)._hash as JsonBasicValueType;
 };

--- a/test/converter.spec.ts
+++ b/test/converter.spec.ts
@@ -1151,6 +1151,151 @@ describe('From JSON', () => {
     ]);
   });
 
+  it('Composite _sliceId (array of field paths) should combine resolved values into one deterministic sliceId.', () => {
+    const json = [
+      { make: 'Volkswagen', model: 'Polo', doors: 5 },
+      { make: 'Volkswagen', model: 'Golf', doors: 3 },
+    ];
+
+    const chart: DecomposeChart = {
+      _sliceId: ['make', 'model'],
+      general: ['doors'],
+    };
+
+    const rljson = fromJson(json, chart);
+    const ids = (rljson.sliceId as any)._data[0].add as string[];
+
+    expect(ids[0]).toBe(
+      (hsh({ make: 'Volkswagen', model: 'Polo' }) as any)._hash,
+    );
+    expect(ids[1]).toBe(
+      (hsh({ make: 'Volkswagen', model: 'Golf' }) as any)._hash,
+    );
+    // Sharing a value in one field but not the other must not collapse the
+    // two items into the same sliceId.
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  it('Composite _sliceId should fall back to a content hash when one of its fields does not resolve for an item.', () => {
+    const json = [
+      { make: 'Volkswagen', model: 'Polo' },
+      // 'model' is missing here, so the composite key ['make', 'model']
+      // cannot fully resolve for this item.
+      { make: 'Volkswagen' },
+    ];
+
+    const chart: DecomposeChart = {
+      _sliceId: ['make', 'model'],
+      general: ['make'],
+    };
+
+    const rljson = fromJson(json, chart);
+    const ids = (rljson.sliceId as any)._data[0].add as string[];
+
+    expect(ids[0]).toBe(
+      (hsh({ make: 'Volkswagen', model: 'Polo' }) as any)._hash,
+    );
+    expect(ids[1]).toBe((hsh(json[1] as any) as any)._hash);
+  });
+
+  it('Composite _sliceId should support nested paths for each of its fields.', () => {
+    const json = {
+      meta: { region: 'EU', id: 'car1' },
+      model: 'X',
+    };
+
+    const chart: DecomposeChart = {
+      _sliceId: ['meta/region', 'meta/id'],
+      general: ['model'],
+    };
+
+    const rljson = fromJson(json, chart);
+    const ids = (rljson.sliceId as any)._data[0].add as string[];
+
+    expect(ids[0]).toBe(
+      (hsh({ 'meta/region': 'EU', 'meta/id': 'car1' }) as any)._hash,
+    );
+  });
+
+  it('Composite _sliceId on a sub-type should combine that sub-type\'s own field values.', async () => {
+    const json = [
+      {
+        id: 'car1',
+        wheels: [
+          { axle: 'front', side: 'left', brand: 'Borbet' },
+          { axle: 'front', side: 'right', brand: 'Borbet' },
+        ],
+      },
+    ];
+
+    const chart: DecomposeChart = {
+      _sliceId: 'id',
+      _name: 'Car',
+      _types: [
+        {
+          _name: 'Wheel',
+          _path: 'wheels',
+          _sliceId: ['axle', 'side'],
+          general: ['brand'],
+        },
+      ],
+    };
+
+    const rljson = fromJson(json, chart);
+
+    const v = new Validate();
+    v.addValidator(new BaseValidator());
+    const result = await v.run(rljson);
+    expect(result).toStrictEqual({});
+
+    const wheelIds = (rljson.wheelSliceId as any)._data[0].add as string[];
+    expect(wheelIds).toEqual([
+      (hsh({ axle: 'front', side: 'left' }) as any)._hash,
+      (hsh({ axle: 'front', side: 'right' }) as any)._hash,
+    ]);
+  });
+
+  it('sliceId@Type reference embedding should use the composite-key hash when the sub-type declares a composite _sliceId.', async () => {
+    const json = [
+      {
+        id: 'car1',
+        screws: [
+          { axle: 'front', side: 'left', material: 'Stainless Steel' },
+          { axle: 'front', side: 'right', material: 'Steel Zinc plated' },
+        ],
+      },
+    ];
+
+    const chart: DecomposeChart = {
+      _sliceId: 'id',
+      _name: 'Car',
+      screwRefs: ['sliceId@Screw'],
+      _types: [
+        {
+          _name: 'Screw',
+          _path: 'screws',
+          _sliceId: ['axle', 'side'],
+          technical: ['material'],
+        },
+      ],
+    };
+
+    const rljson = fromJson(json, chart);
+
+    const v = new Validate();
+    v.addValidator(new BaseValidator());
+    const result = await v.run(rljson);
+    expect(result).toStrictEqual({});
+
+    const embeddedIds = (rljson.carScrewRefs as any)._data[0]
+      .screwSliceId as string[];
+
+    expect(embeddedIds).toEqual([
+      (hsh({ axle: 'front', side: 'left' }) as any)._hash,
+      (hsh({ axle: 'front', side: 'right' }) as any)._hash,
+    ]);
+  });
+
   it('List w/ types and references with nested sliceIds should convert w/o errors.', async () => {
     const json = [
       {


### PR DESCRIPTION
## Summary
- `_sliceId` now accepts `string | string[]`. When given an array, each path is resolved independently and the resolved values are combined into one deterministic sliceId by hashing the `{path: value}` record (avoids delimiter-collision issues a naive join would have).
- Falls back to the existing whole-item content hash if any one field of the composite key doesn't resolve, matching current single-path fallback behavior.
- Works uniformly for the main chart, `_types` sub-types, and `sliceId@Type` reference embedding, since they all funnel through `resolveSliceIdWithFallback`.
- Pinned `typescript` back to `~6.0.3` after `pnpm update --latest` pulled in `7.0.2`, which breaks `typescript-eslint`'s `<6.1.0` peer ceiling (confirmed via `pnpm exec eslint`).

## Test plan
- [x] `pnpm test` (vitest + coverage + eslint) — 100% statements/branches/functions/lines
- [x] `pnpm run build` — vite build + tsc succeed
- [x] New tests cover: two-field composite key on main chart, partial-resolution fallback, nested `/` paths within a composite key, composite key on a `_types` sub-type, and `sliceId@Type` embedding of a composite-keyed sub-type