### PR TITLE
Fix missing imports in is-main-up-to-date.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rljson/converter",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "description": "Convert flat textual data i. e. from JSON or XML into RLJSON data structure and data itself automatically.",
   "homepage": "https://github.com/rljson/converter",
   "bugs": "https://github.com/rljson/converter/issues",

--- a/scripts/functions/is-main-up-to-date.js
+++ b/scripts/functions/is-main-up-to-date.js
@@ -6,6 +6,9 @@
  * found in the LICENSE file in the root of this package.
  */
 
+import { execSync } from 'child_process';
+import { red } from './colors.js';
+
 export const isMainUpToDate = () => {
   try {
     execSync('git fetch origin main');


### PR DESCRIPTION
## Summary
- \`isMainUpToDate()\` referenced \`execSync\` and \`red\` without importing either, so any failure path crashed with an uncaught \`ReferenceError\` instead of the intended clean-repo error message.
- Discovered while running \`scripts/add-version-tag.js\` as part of publishing \`@rljson/converter\`.

## Test plan
- [x] \`pnpm run build\` (tests + lint + build) passes at 100% coverage — scripts/ is outside the coverage-tracked \`src/\` tree
- [x] Re-ran \`node scripts/add-version-tag.js\` after the fix and confirmed it now reports the correct branch-state error instead of crashing