### PR TITLE
Fold row position into sliceId fallback hash; add size-property test

### DIFF
--- a/README.public.md
+++ b/README.public.md
@@ -138,14 +138,15 @@ const chart: DecomposeChart = {
 Each wheel still becomes its own individually addressable row, without
 requiring a natural key in the source data.
 
-**Limitation:** since the fallback is a pure function of content, two sibling
-sub-objects with byte-identical content and no natural key produce the *same*
-fallback sliceId and collapse into a single addressable slice (e.g. two
-structurally-identical wheels under one car would be recorded as one wheel
-reference, not two). This mirrors how identical content already collapses to
-a single component row elsewhere in the converter. If you need to count or
-reference every occurrence individually, the source data needs a natural key
-(or one added during pre-processing).
+The fallback folds each item's position within its array into the content
+hash, so two sibling sub-objects with byte-identical content and no natural
+key still get *distinct* fallback sliceIds (e.g. two structurally-identical
+wheels under one car are recorded as two separate wheel references, not one).
+This is independent of component-level deduplication: the underlying
+`brand: 'Borbet'` data still collapses to a single shared component row (as
+identical content does everywhere else in the converter) — only the sliceId
+identity, and therefore the ability to address/count each occurrence
+individually, is kept distinct.
 
 #### Component Definition
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rljson/converter",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "Convert flat textual data i. e. from JSON or XML into RLJSON data structure and data itself automatically.",
   "homepage": "https://github.com/rljson/converter",
   "bugs": "https://github.com/rljson/converter/issues",

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -138,10 +138,15 @@ const resolveCompositeSliceId = (
 
 // Falls back to a content hash of the item when no _sliceId path is
 // declared, or the declared path(s) do not resolve for this item — this
-// gives every item a stable identity even without a natural key.
+// gives every item a stable identity even without a natural key. The index
+// (an item's position within the array it is being resolved from) is folded
+// into that hash so that two items with identical content — but no key to
+// tell them apart — still get distinct fallback ids instead of silently
+// colliding into a single slice.
 const resolveSliceIdWithFallback = (
   item: Json,
   path: string | string[] | undefined,
+  index: number,
 ): JsonBasicValueType => {
   const resolved = path
     ? Array.isArray(path)
@@ -149,7 +154,8 @@ const resolveSliceIdWithFallback = (
       : resolveSliceId(item, path)
     : undefined;
   if (resolved !== undefined && resolved !== null) return resolved;
-  return hsh(item)._hash as JsonBasicValueType;
+  return hsh({ ...item, __rowIndex: index } as Json)
+    ._hash as JsonBasicValueType;
 };
 
 // Resolves a nested object by walking a slash-separated path.
@@ -172,6 +178,8 @@ const resolvePropertySliceId = (
   refType: string,
   chart: DecomposeChart,
   destination?: string,
+  itemIndex: number = 0,
+  subItemOffsets: Map<string, number[]> = new Map(),
 ) => {
   const typesIndexed: { [key: string]: string | undefined } = {};
   for (const t of chart._types!) {
@@ -202,9 +210,19 @@ const resolvePropertySliceId = (
     ? (resolvedTypePath as Array<Json>)
     : ([resolvedTypePath] as Array<Json>);
 
-  for (const refObj of refObjs) {
+  // Base offset of this parent item's own sub-items within the flattened
+  // array the referenced sub-type's own sliceIds table was built from — this
+  // keeps the fallback index (and therefore the resulting hash) aligned with
+  // the id that sub-type actually assigned to the same object.
+  const baseOffset = subItemOffsets.get(refType)?.[itemIndex] ?? 0;
+
+  for (let j = 0; j < refObjs.length; j++) {
     sliceIds.push(
-      resolveSliceIdWithFallback(refObj, typeSliceId) as SliceIdsRef,
+      resolveSliceIdWithFallback(
+        refObjs[j],
+        typeSliceId,
+        baseOffset + j,
+      ) as SliceIdsRef,
     );
   }
 
@@ -306,6 +324,8 @@ const nestedProperty = (
   chart?: DecomposeChart,
   nestedRljson?: Rljson,
   destination?: string,
+  itemIndex: number = 0,
+  subItemOffsets: Map<string, number[]> = new Map(),
 ) => {
   if (typeof path === 'object' && 'destination' in path && 'origin' in path) {
     const pathParsed = path as DecomposeChartComponentPropertyDef;
@@ -315,6 +335,8 @@ const nestedProperty = (
       chart,
       nestedRljson,
       pathParsed.destination,
+      itemIndex,
+      subItemOffsets,
     );
   } else {
     const keys = Array.isArray(path)
@@ -339,7 +361,14 @@ const nestedProperty = (
         const refType = key.split('@')[1];
 
         if (refComp === 'sliceId') {
-          return resolvePropertySliceId(obj, refType, chart, destination);
+          return resolvePropertySliceId(
+            obj,
+            refType,
+            chart,
+            destination,
+            itemIndex,
+            subItemOffsets,
+          );
         } else {
           return resolvePropertyReference(
             key,
@@ -361,6 +390,8 @@ const nestedProperty = (
         chart,
         nestedRljson,
         destination,
+        itemIndex,
+        subItemOffsets,
       );
     }
   }
@@ -373,6 +404,7 @@ const createComponent = (
   typeName?: string,
   chart?: DecomposeChart,
   nestedRljson?: Rljson,
+  subItemOffsets: Map<string, number[]> = new Map(),
 ) => {
   if (Array.isArray(componentProperties)) {
     //Array of properties --> loop through properties and collect them as
@@ -385,7 +417,15 @@ const createComponent = (
       for (const componentProperty of componentProperties as string[]) {
         Object.assign(
           obj,
-          nestedProperty(item, componentProperty, chart, nestedRljson),
+          nestedProperty(
+            item,
+            componentProperty,
+            chart,
+            nestedRljson,
+            undefined,
+            idx,
+            subItemOffsets,
+          ),
         );
       }
       compArr[idx] = obj;
@@ -413,6 +453,7 @@ const createComponent = (
           typeName,
           chart,
           nestedRljson,
+          subItemOffsets,
         ),
       );
     }
@@ -618,6 +659,11 @@ export const fromJson = (
     string,
     { sliceIdMap: Map<string, string[]>; cakeRef: string }
   >();
+  // For every sub-type, the global starting offset (within that sub-type's
+  // own flattened, index-aligned item list) of each parent item's sub-items —
+  // lets sliceId@Type embedding (further below) recompute the exact same
+  // fallback id the sub-type itself assigned to a keyless sub-item.
+  const subItemStartOffsets = new Map<string, number[]>();
   if (chart._types && Array.isArray(chart._types)) {
     for (const subType of chart._types as DecomposeChart[]) {
       // Items whose _path does not resolve contribute no sub-items rather
@@ -636,12 +682,24 @@ export const fromJson = (
       // an empty shell of tables (sliceIds/components/cake/relation) for it.
       if (nestedJson.length === 0) continue;
 
+      let runningOffset = 0;
+      const startOffsets = subItemsPerItem.map((items) => {
+        const start = runningOffset;
+        runningOffset += items.length;
+        return start;
+      });
+      subItemStartOffsets.set(subType._name as string, startOffsets);
+
       //Collect sliceIds of nested type for reference resolution
       const nestedSliceIds = new Map<string, string[]>(
         json.map((item, idx) => [
-          resolveSliceIdWithFallback(item, chart._sliceId) as string,
-          subItemsPerItem[idx].map((subItem: any) =>
-            resolveSliceIdWithFallback(subItem, subType._sliceId),
+          resolveSliceIdWithFallback(item, chart._sliceId, idx) as string,
+          subItemsPerItem[idx].map((subItem: any, j: number) =>
+            resolveSliceIdWithFallback(
+              subItem,
+              subType._sliceId,
+              startOffsets[idx] + j,
+            ),
           ) as string[],
         ]),
       );
@@ -675,16 +733,23 @@ export const fromJson = (
     }
   }
 
-  const ids = json.map((item) =>
-    resolveSliceIdWithFallback(item, chart._sliceId),
+  const ids = json.map((item, idx) =>
+    resolveSliceIdWithFallback(item, chart._sliceId, idx),
   );
+
+  // Several items may resolve to the same slice id (e.g. two items sharing
+  // one explicitly declared natural key). The "add" list is the set of slice
+  // ids added to this table, so it must not contain repeats — even though
+  // `ids` itself keeps one entry per source item for the index-aligned
+  // lookups below (layers, relations).
+  const uniqueIds = [...new Set(ids)];
 
   const sliceIds: SliceIdsTable = hip(
     {
       _type: 'sliceIds',
       _data: [
         {
-          add: ids as SliceIdsRef[],
+          add: uniqueIds as SliceIdsRef[],
         },
       ],
     },
@@ -709,6 +774,7 @@ export const fromJson = (
           chart._name,
           chart,
           nestedRljson,
+          subItemStartOffsets,
         ),
       );
     }

--- a/test/converter.spec.ts
+++ b/test/converter.spec.ts
@@ -519,6 +519,66 @@ describe('From JSON', () => {
     );
     expect(result).toStrictEqual({});
   });
+  it('List w/ types, references and an additional flat property should convert w/o errors.', async () => {
+    const json = [
+      {
+        id: 'car1',
+        color: {
+          id: 'RAL9000',
+          name: 'Black',
+        },
+      },
+      {
+        id: 'car2',
+        color: {
+          id: 'RAL7000',
+          name: 'Gray',
+        },
+      },
+      {
+        id: 'car3',
+        color: {
+          id: 'RAL9000',
+          name: 'Black',
+        },
+        size: 'large',
+      },
+      {
+        id: 'car4',
+        color: {
+          id: 'RAL7000',
+          name: 'Gray',
+        },
+        size: 'medium',
+      },
+    ];
+
+    const chart: DecomposeChart = {
+      _sliceId: 'id',
+      _name: 'Car',
+      colorRefs: ['sliceId@Color', 'general@Color'],
+      size: ['size'],
+      _types: [
+        {
+          _name: 'Color',
+          _path: 'color',
+          _sliceId: 'id',
+          general: ['name'],
+        },
+      ],
+    };
+
+    const rljson = fromJson(json, chart);
+
+    const v = new Validate();
+    v.addValidator(new BaseValidator());
+    const result = await v.run(rljson);
+
+    await expectGolden(
+      'example/converter/list-with-types-and-refs-and-size.json',
+    ).toBe(rljson);
+    expect(result).toStrictEqual({});
+  });
   it('Object with nested components should convert w/o errors.', async () => {
     const json = {
       id: 'car1',

--- a/test/converter.spec.ts
+++ b/test/converter.spec.ts
@@ -1074,10 +1074,12 @@ describe('From JSON', () => {
     const ids = (rljson.sliceId as any)._data[0].add as string[];
 
     expect(ids[0]).toBe('car1');
-    expect(ids[1]).toBe(hsh(json[1] as any)._hash);
+    expect(ids[1]).toBe(
+      hsh({ ...(json[1] as any), __rowIndex: 1 } as any)._hash,
+    );
   });
 
-  it('Basic objects List with no _sliceId declared should derive one from a content hash.', () => {
+  it('Basic objects List with no _sliceId declared should derive a distinct id per item from a content-and-position hash.', () => {
     const json = [{ model: 'X' }, { model: 'Y' }, { model: 'X' }];
 
     const chart: DecomposeChart = {
@@ -1087,13 +1089,16 @@ describe('From JSON', () => {
     const rljson = fromJson(json, chart);
     const ids = (rljson.sliceId as any)._data[0].add as string[];
 
-    expect(ids[0]).toBe((hsh({ model: 'X' }) as any)._hash);
-    expect(ids[1]).toBe((hsh({ model: 'Y' }) as any)._hash);
-    // Identical content produces the identical fallback sliceId.
-    expect(ids[2]).toBe(ids[0]);
+    expect(ids[0]).toBe((hsh({ model: 'X', __rowIndex: 0 }) as any)._hash);
+    expect(ids[1]).toBe((hsh({ model: 'Y', __rowIndex: 1 }) as any)._hash);
+    expect(ids[2]).toBe((hsh({ model: 'X', __rowIndex: 2 }) as any)._hash);
+    // Item 0 and item 2 share identical content but its position in the
+    // array is folded into the fallback hash, so they no longer collide into
+    // the same sliceId.
+    expect(ids[2]).not.toBe(ids[0]);
   });
 
-  it('List w/ types and no natural key on the sub-type should derive sliceIds from a content hash.', async () => {
+  it('List w/ types and no natural key on the sub-type should derive sliceIds from a content-and-position hash.', async () => {
     const json = [
       {
         id: 'car1',
@@ -1122,12 +1127,12 @@ describe('From JSON', () => {
 
     const wheelIds = (rljson.wheelSliceId as any)._data[0].add as string[];
     expect(wheelIds).toEqual([
-      (hsh({ brand: 'Borbet' }) as any)._hash,
-      (hsh({ brand: 'Michelin' }) as any)._hash,
+      (hsh({ brand: 'Borbet', __rowIndex: 0 }) as any)._hash,
+      (hsh({ brand: 'Michelin', __rowIndex: 1 }) as any)._hash,
     ]);
   });
 
-  it('List w/ types and duplicate-content sub-items with no natural key collapse into one addressable slice (documented tradeoff).', async () => {
+  it('List w/ types and duplicate-content sub-items with no natural key should still get distinct, addressable slices.', async () => {
     const json = [
       {
         id: 'car1',
@@ -1155,18 +1160,21 @@ describe('From JSON', () => {
     expect(result).toStrictEqual({});
 
     // Two physically distinct wheels with identical content and no natural
-    // key cannot be told apart by a content-hash-derived sliceId — they
-    // collapse into a single addressable slice. This mirrors how identical
-    // content already collapses to one component row elsewhere in the
-    // converter, and is an accepted, documented tradeoff (see
-    // README.public.md), not a bug.
+    // key cannot be told apart by content alone — but their position within
+    // the array is folded into the fallback sliceId, so they still get two
+    // distinct, addressable slices instead of collapsing into one.
     const wheelIds = (rljson.wheelSliceId as any)._data[0].add as string[];
-    expect(new Set(wheelIds).size).toBe(1);
+    expect(new Set(wheelIds).size).toBe(2);
 
     const wheelGeneralLayer = (rljson.wheelGeneralLayer as any)._data[0]
       .add as Record<string, string>;
-    expect(Object.keys(wheelGeneralLayer).filter((k) => k !== '_hash')).toHaveLength(1);
+    expect(
+      Object.keys(wheelGeneralLayer).filter((k) => k !== '_hash'),
+    ).toHaveLength(2);
 
+    // The underlying "brand: Borbet" content is still genuinely identical,
+    // so — independently of sliceId identity — it still collapses to one
+    // shared component row; both distinct wheel slices point at it.
     expect((rljson.wheelGeneral as any)._data).toHaveLength(1);
   });
 
@@ -1205,10 +1213,77 @@ describe('From JSON', () => {
       .screwSliceId as string[];
 
     expect(embeddedIds).toEqual([
-      (hsh({ material: 'Stainless Steel', dimension: 'M4x20' }) as any)._hash,
-      (hsh({ material: 'Steel Zinc plated', dimension: 'M6x30' }) as any)
-        ._hash,
+      (
+        hsh({
+          material: 'Stainless Steel',
+          dimension: 'M4x20',
+          __rowIndex: 0,
+        }) as any
+      )._hash,
+      (
+        hsh({
+          material: 'Steel Zinc plated',
+          dimension: 'M6x30',
+          __rowIndex: 1,
+        }) as any
+      )._hash,
     ]);
+  });
+
+  it('sliceId@Type embedded inside a general@Type-synthesized sub-component should still resolve w/o errors.', async () => {
+    // general@Type re-synthesizes the referenced type's own component
+    // independently (see resolvePropertyReference), outside of the recursive
+    // fromJson call that originally built that type's tables. When the
+    // referenced component itself contains a sliceId@Type reference to a
+    // further keyless sub-type, that re-synthesis has no way to know the
+    // real base offset the original recursive call assigned — it falls back
+    // to treating the item as if it were first (offset 0).
+    const json = [
+      {
+        id: 'car1',
+        colors: [{ id: 'RAL9000', pigments: [{ name: 'Titanium White' }] }],
+      },
+    ];
+
+    const chart: DecomposeChart = {
+      _sliceId: 'id',
+      _name: 'Car',
+      colorRefs: ['general@Color'],
+      _types: [
+        {
+          _name: 'Color',
+          _path: 'colors',
+          _sliceId: 'id',
+          general: ['sliceId@Pigment'],
+          _types: [
+            {
+              _name: 'Pigment',
+              _path: 'pigments',
+              info: ['name'],
+            },
+          ],
+        },
+      ],
+    };
+
+    const rljson = fromJson(json, chart);
+
+    const v = new Validate();
+    v.addValidator(new BaseValidator());
+    const result = await v.run(rljson);
+    expect(result).toStrictEqual({});
+
+    const embeddedRef = (rljson.carColorRefs as any)._data[0]
+      .colorGeneral as string[];
+    expect(embeddedRef).toHaveLength(1);
+
+    // With a single color and a single pigment, the real base offset and the
+    // offset-0 fallback happen to coincide, so the re-synthesized reference
+    // still points at an actual row of the real colorGeneral table.
+    const colorGeneralHashes = (rljson.colorGeneral as any)._data.map(
+      (row: any) => row._hash,
+    );
+    expect(colorGeneralHashes).toContain(embeddedRef[0]);
   });
 
   it('Composite _sliceId (array of field paths) should combine resolved values into one deterministic sliceId.', () => {
@@ -1255,7 +1330,9 @@ describe('From JSON', () => {
     expect(ids[0]).toBe(
       (hsh({ make: 'Volkswagen', model: 'Polo' }) as any)._hash,
     );
-    expect(ids[1]).toBe((hsh(json[1] as any) as any)._hash);
+    expect(ids[1]).toBe(
+      (hsh({ ...(json[1] as any), __rowIndex: 1 }) as any)._hash,
+    );
   });
 
   it('Composite _sliceId should support nested paths for each of its fields.', () => {

--- a/test/goldens/example/converter/deepfruits-with-types.json
+++ b/test/goldens/example/converter/deepfruits-with-types.json
@@ -318,17 +318,17 @@
       {
         "usess": [
           {
-            "ref": "CxeXsW0tRqIr2eq8PGlgpf",
+            "ref": "jcKIEBq8jWhPbu7dLatTOR",
             "sliceIds": [
               true
             ],
-            "_hash": "F0zjSIrpCO9SaWurNtPnvQ"
+            "_hash": "ADdQw6_3G5pzazGvnxQRW-"
           }
         ],
-        "_hash": "DpXbgjPKTcgn82sJ5TF0SB"
+        "_hash": "jKCg21xvNx5NRMrshjERq4"
       }
     ],
-    "_hash": "jUE8c_hA9GRVpZ-JHST9vV",
+    "_hash": "6ejCy_PMMPm0kINpT9ilXC",
     "tableCfg": "VpnSRbmX8HYjDYip3QCMqW"
   },
   "fruitUsessLayer": {
@@ -336,17 +336,17 @@
     "_data": [
       {
         "add": {
-          "Apple": "DpXbgjPKTcgn82sJ5TF0SB",
-          "Pear": "DpXbgjPKTcgn82sJ5TF0SB",
-          "_hash": "zMHyh9zS5HOpvuw4svX1si"
+          "Apple": "jKCg21xvNx5NRMrshjERq4",
+          "Pear": "jKCg21xvNx5NRMrshjERq4",
+          "_hash": "Hxd6R8rwSm-SvRMz99A1wb"
         },
         "sliceIdsTable": "fruitSliceId",
         "sliceIdsTableRow": "RD8MjfsilUaUdIPb_XoMIN",
         "componentsTable": "fruitUsess",
-        "_hash": "ylPOQ1yQmreQefgkqlqYoH"
+        "_hash": "nhn4OHApXFSQba_Ydu5J31"
       }
     ],
-    "_hash": "uCKKbFwxSMrEtS_W1kEEFC",
+    "_hash": "o9oCoz2BJqRYMvsh8_WSwX",
     "tableCfg": "ZO_9Ik64oZodKOuOkGDkdA"
   },
   "fruitShapess": {
@@ -410,28 +410,27 @@
           "fruitRetailInfoLayer": "xGJenCxBHba64quWWdnL9y",
           "fruitNutrientsLayer": "nGsRkEzmqw2BI9hzxjhxOE",
           "fruitUsesRefsLayer": "Ar2qwkepQyJ4cDiLDiiRV-",
-          "fruitUsessLayer": "ylPOQ1yQmreQefgkqlqYoH",
+          "fruitUsessLayer": "nhn4OHApXFSQba_Ydu5J31",
           "fruitShapessLayer": "DWRIda-bjAfwTQMOsbamD8",
-          "_hash": "b4XxYHiaAjknkFhip_gdMu"
+          "_hash": "uSqOz-k5Qv7TE5SlHHc7Jd"
         },
-        "_hash": "AFMnfIx0pQ5urXQfVsblHC"
+        "_hash": "rU7Gf3gFN_SZdoq8-UnkU3"
       }
     ],
     "tableCfg": "fgOwpAjw9WdJx7RDIDcRPM",
-    "_hash": "ZaryvuSzvKKWAPwDPcsMYG"
+    "_hash": "QP-S5vs9Z56GjtVszoXtXv"
   },
   "usesSliceId": {
     "_type": "sliceIds",
     "_data": [
       {
         "add": [
-          true,
           true
         ],
-        "_hash": "rasZveZCDbBjew6BZKyvrj"
+        "_hash": "XuALpNVLwV2Ju9CK2X1nfr"
       }
     ],
-    "_hash": "nvomk665cmmIOEe8TxRJ3b",
+    "_hash": "iDsdGurl00Ey5noFr0km7k",
     "tableCfg": "Icw0DGNpqFMMyGDWH_rRhK"
   },
   "usesFurther": {
@@ -457,12 +456,12 @@
           "_hash": "7igXYJcJDD1Nu6o3AVh20J"
         },
         "sliceIdsTable": "usesSliceId",
-        "sliceIdsTableRow": "rasZveZCDbBjew6BZKyvrj",
+        "sliceIdsTableRow": "XuALpNVLwV2Ju9CK2X1nfr",
         "componentsTable": "usesFurther",
-        "_hash": "IWeWRUSJ2EmT-7LKcJ-uD0"
+        "_hash": "wo5uA4ciIEqkgoFbXGsqJ_"
       }
     ],
-    "_hash": "CHiqbTQ8LvU0oYCBEU5I98",
+    "_hash": "F238DBp5VpZmWICmJooF2p",
     "tableCfg": "ieAo49bzmQL8VefzWV4wNw"
   },
   "usesFurtherInsertHistory": {
@@ -512,16 +511,16 @@
     "_data": [
       {
         "sliceIdsTable": "usesSliceId",
-        "sliceIdsRow": "rasZveZCDbBjew6BZKyvrj",
+        "sliceIdsRow": "XuALpNVLwV2Ju9CK2X1nfr",
         "layers": {
-          "usesFurtherLayer": "IWeWRUSJ2EmT-7LKcJ-uD0",
-          "_hash": "CtCGLmyWJalWDKKNkdRmd7"
+          "usesFurtherLayer": "wo5uA4ciIEqkgoFbXGsqJ_",
+          "_hash": "6GIVb4PlviFjFr-SQ2bs8r"
         },
-        "_hash": "CxeXsW0tRqIr2eq8PGlgpf"
+        "_hash": "jcKIEBq8jWhPbu7dLatTOR"
       }
     ],
     "tableCfg": "pdRjzWVBcGrMO8xCKlqO4L",
-    "_hash": "dODJXVscxLXhIlVSnEAsYZ"
+    "_hash": "GLf3n87mnw769KA2nRr8_m"
   },
   "shapesSliceId": {
     "_type": "sliceIds",
@@ -3577,5 +3576,5 @@
     ],
     "_hash": "rd8MfZ5FgqwBCxsaPt06Un"
   },
-  "_hash": "3Ed4RPSbYIxi4ptWKPPwRn"
+  "_hash": "o4lVPz8RepSdFkoit5-qGn"
 }

--- a/test/goldens/example/converter/fruits-with-types.json
+++ b/test/goldens/example/converter/fruits-with-types.json
@@ -318,17 +318,17 @@
       {
         "usess": [
           {
-            "ref": "CxeXsW0tRqIr2eq8PGlgpf",
+            "ref": "jcKIEBq8jWhPbu7dLatTOR",
             "sliceIds": [
               true
             ],
-            "_hash": "F0zjSIrpCO9SaWurNtPnvQ"
+            "_hash": "ADdQw6_3G5pzazGvnxQRW-"
           }
         ],
-        "_hash": "DpXbgjPKTcgn82sJ5TF0SB"
+        "_hash": "jKCg21xvNx5NRMrshjERq4"
       }
     ],
-    "_hash": "jUE8c_hA9GRVpZ-JHST9vV",
+    "_hash": "6ejCy_PMMPm0kINpT9ilXC",
     "tableCfg": "VpnSRbmX8HYjDYip3QCMqW"
   },
   "fruitUsessLayer": {
@@ -336,17 +336,17 @@
     "_data": [
       {
         "add": {
-          "Apple": "DpXbgjPKTcgn82sJ5TF0SB",
-          "Pear": "DpXbgjPKTcgn82sJ5TF0SB",
-          "_hash": "zMHyh9zS5HOpvuw4svX1si"
+          "Apple": "jKCg21xvNx5NRMrshjERq4",
+          "Pear": "jKCg21xvNx5NRMrshjERq4",
+          "_hash": "Hxd6R8rwSm-SvRMz99A1wb"
         },
         "sliceIdsTable": "fruitSliceId",
         "sliceIdsTableRow": "RD8MjfsilUaUdIPb_XoMIN",
         "componentsTable": "fruitUsess",
-        "_hash": "ylPOQ1yQmreQefgkqlqYoH"
+        "_hash": "nhn4OHApXFSQba_Ydu5J31"
       }
     ],
-    "_hash": "uCKKbFwxSMrEtS_W1kEEFC",
+    "_hash": "o9oCoz2BJqRYMvsh8_WSwX",
     "tableCfg": "ZO_9Ik64oZodKOuOkGDkdA"
   },
   "fruitShapess": {
@@ -410,28 +410,27 @@
           "fruitRetailInfoLayer": "xGJenCxBHba64quWWdnL9y",
           "fruitNutrientsLayer": "nGsRkEzmqw2BI9hzxjhxOE",
           "fruitUsesRefsLayer": "Ar2qwkepQyJ4cDiLDiiRV-",
-          "fruitUsessLayer": "ylPOQ1yQmreQefgkqlqYoH",
+          "fruitUsessLayer": "nhn4OHApXFSQba_Ydu5J31",
           "fruitShapessLayer": "DWRIda-bjAfwTQMOsbamD8",
-          "_hash": "b4XxYHiaAjknkFhip_gdMu"
+          "_hash": "uSqOz-k5Qv7TE5SlHHc7Jd"
         },
-        "_hash": "AFMnfIx0pQ5urXQfVsblHC"
+        "_hash": "rU7Gf3gFN_SZdoq8-UnkU3"
       }
     ],
     "tableCfg": "fgOwpAjw9WdJx7RDIDcRPM",
-    "_hash": "ZaryvuSzvKKWAPwDPcsMYG"
+    "_hash": "QP-S5vs9Z56GjtVszoXtXv"
   },
   "usesSliceId": {
     "_type": "sliceIds",
     "_data": [
       {
         "add": [
-          true,
           true
         ],
-        "_hash": "rasZveZCDbBjew6BZKyvrj"
+        "_hash": "XuALpNVLwV2Ju9CK2X1nfr"
       }
     ],
-    "_hash": "nvomk665cmmIOEe8TxRJ3b",
+    "_hash": "iDsdGurl00Ey5noFr0km7k",
     "tableCfg": "Icw0DGNpqFMMyGDWH_rRhK"
   },
   "usesFurther": {
@@ -457,12 +456,12 @@
           "_hash": "7igXYJcJDD1Nu6o3AVh20J"
         },
         "sliceIdsTable": "usesSliceId",
-        "sliceIdsTableRow": "rasZveZCDbBjew6BZKyvrj",
+        "sliceIdsTableRow": "XuALpNVLwV2Ju9CK2X1nfr",
         "componentsTable": "usesFurther",
-        "_hash": "IWeWRUSJ2EmT-7LKcJ-uD0"
+        "_hash": "wo5uA4ciIEqkgoFbXGsqJ_"
       }
     ],
-    "_hash": "CHiqbTQ8LvU0oYCBEU5I98",
+    "_hash": "F238DBp5VpZmWICmJooF2p",
     "tableCfg": "ieAo49bzmQL8VefzWV4wNw"
   },
   "usesFurtherInsertHistory": {
@@ -512,16 +511,16 @@
     "_data": [
       {
         "sliceIdsTable": "usesSliceId",
-        "sliceIdsRow": "rasZveZCDbBjew6BZKyvrj",
+        "sliceIdsRow": "XuALpNVLwV2Ju9CK2X1nfr",
         "layers": {
-          "usesFurtherLayer": "IWeWRUSJ2EmT-7LKcJ-uD0",
-          "_hash": "CtCGLmyWJalWDKKNkdRmd7"
+          "usesFurtherLayer": "wo5uA4ciIEqkgoFbXGsqJ_",
+          "_hash": "6GIVb4PlviFjFr-SQ2bs8r"
         },
-        "_hash": "CxeXsW0tRqIr2eq8PGlgpf"
+        "_hash": "jcKIEBq8jWhPbu7dLatTOR"
       }
     ],
     "tableCfg": "pdRjzWVBcGrMO8xCKlqO4L",
-    "_hash": "dODJXVscxLXhIlVSnEAsYZ"
+    "_hash": "GLf3n87mnw769KA2nRr8_m"
   },
   "shapesSliceId": {
     "_type": "sliceIds",
@@ -3577,5 +3576,5 @@
     ],
     "_hash": "rd8MfZ5FgqwBCxsaPt06Un"
   },
-  "_hash": "3Ed4RPSbYIxi4ptWKPPwRn"
+  "_hash": "o4lVPz8RepSdFkoit5-qGn"
 }

--- a/test/goldens/example/converter/list-with-types-and-refs-and-size.json
+++ b/test/goldens/example/converter/list-with-types-and-refs-and-size.json
@@ -1,0 +1,1870 @@
+{
+  "carSliceId": {
+    "_type": "sliceIds",
+    "_data": [
+      {
+        "add": [
+          "car1",
+          "car2",
+          "car3",
+          "car4"
+        ],
+        "_hash": "qrZ-9U_R84uJbplGsEj3Ns"
+      }
+    ],
+    "_hash": "LBDqx9xr3aP00p3V2-VU9-",
+    "tableCfg": "4yM_dWqrCcWxWyt93d4LJx"
+  },
+  "carColorRefs": {
+    "_data": [
+      {
+        "colorSliceId": [
+          "RAL9000"
+        ],
+        "colorGeneral": [],
+        "_hash": "Z31mhO2Lp9I82wDgt4ygUK"
+      },
+      {
+        "colorSliceId": [
+          "RAL7000"
+        ],
+        "colorGeneral": [],
+        "_hash": "LcrAW9z0xTAX4xFLuIIi85"
+      }
+    ],
+    "_type": "components",
+    "_hash": "QfgFfbD09b8vyKieZV_GgE",
+    "tableCfg": "PI1-B4c1Qcq5yzVBgY3kmc"
+  },
+  "carSize": {
+    "_data": [
+      {
+        "_hash": "RBNvo1WzZ4oRRq0W9-hknp"
+      },
+      {
+        "size": "large",
+        "_hash": "xWYyqLKwxRvvNBViJwrat-"
+      },
+      {
+        "size": "medium",
+        "_hash": "ziDKJS0bBu1x3cm2zk99Xo"
+      }
+    ],
+    "_type": "components",
+    "_hash": "tHAAXUlguJUakQ3tuD6Jl4",
+    "tableCfg": "2qSfMPoOctShgHpaKA8V4g"
+  },
+  "carColorRefsLayer": {
+    "_type": "layers",
+    "_data": [
+      {
+        "add": {
+          "car1": "Z31mhO2Lp9I82wDgt4ygUK",
+          "car2": "LcrAW9z0xTAX4xFLuIIi85",
+          "car3": "Z31mhO2Lp9I82wDgt4ygUK",
+          "car4": "LcrAW9z0xTAX4xFLuIIi85",
+          "_hash": "DYVgPXEyg5vL6s4-U4i-M8"
+        },
+        "sliceIdsTable": "carSliceId",
+        "sliceIdsTableRow": "qrZ-9U_R84uJbplGsEj3Ns",
+        "componentsTable": "carColorRefs",
+        "_hash": "w7S1giJpHSrAef40mQMmnL"
+      }
+    ],
+    "_hash": "aTSzxsu5_oqwsZ2HZVd4dj",
+    "tableCfg": "1vwnm5_U23zQICZu8WRQWM"
+  },
+  "carSizeLayer": {
+    "_type": "layers",
+    "_data": [
+      {
+        "add": {
+          "car1": "RBNvo1WzZ4oRRq0W9-hknp",
+          "car2": "RBNvo1WzZ4oRRq0W9-hknp",
+          "car3": "xWYyqLKwxRvvNBViJwrat-",
+          "car4": "ziDKJS0bBu1x3cm2zk99Xo",
+          "_hash": "b9IKSeZpD9qCU2D2Iw4NAe"
+        },
+        "sliceIdsTable": "carSliceId",
+        "sliceIdsTableRow": "qrZ-9U_R84uJbplGsEj3Ns",
+        "componentsTable": "carSize",
+        "_hash": "gEWGBhgXtnmcMsRWcsX8NC"
+      }
+    ],
+    "_hash": "oW1A7BLmoZSO8g9o4brNZG",
+    "tableCfg": "QnJunuxWX9EcOWlpsOLzQp"
+  },
+  "carColorRefsInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "8jQV6X1PqZ4BHUuMu2uVq3",
+    "_hash": "ENrO36NqpnRGd6fG4bqKk_"
+  },
+  "carSizeInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "rVqlfr04LLtP1q1hwpObC_",
+    "_hash": "6az2fZ8Z4KFVctjNMaBf1b"
+  },
+  "carColorRefsLayerInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "XSGJwbans5KIiwRy-QazyF",
+    "_hash": "BDltn2fRGC4NZ_bEezi1Wq"
+  },
+  "carSizeLayerInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "wOzWvQb9AKPjrMtluOI65p",
+    "_hash": "5YdIM7DG6zhTf5DK9ToRy8"
+  },
+  "carCakeInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "_eXrlfD9KZoKT9R4jdwpxT",
+    "_hash": "A0C4hITUV-Vp8WBqSDTb4Z"
+  },
+  "carSliceIdInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "s-EtjxRq07guJgj8eZbLqe",
+    "_hash": "jVUTXwUHRr2R6WeBBSXZPz"
+  },
+  "carColorsInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "_QS0K--SIdA9jl8oQwQCT1",
+    "_hash": "ofc1KQM_03roPIP6XhVZ6g"
+  },
+  "carColorsLayerInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "wgy5AnQeSI5pNqMRwNEw1J",
+    "_hash": "oiqYe-SsKKdHdy0oKmjUyx"
+  },
+  "carCakeEdits": {
+    "_type": "edits",
+    "_data": [],
+    "_hash": "bEJx2-GnNSkqqJyvDvzi9l",
+    "tableCfg": "rBF6n_3eM0lYFWAII4OwIz"
+  },
+  "carCakeMultiEdits": {
+    "_type": "multiEdits",
+    "_data": [],
+    "_hash": "DRISrQZybQokng2oC4s0Zl",
+    "tableCfg": "8VfY2MvZQZTl25t-jwr-yH"
+  },
+  "carCakeEditHistory": {
+    "_type": "editHistory",
+    "_data": [],
+    "_hash": "1GY9GMRH8osa6YKCq0u-ou",
+    "tableCfg": "d_SJjAnmrriCG_D7XSfVyO"
+  },
+  "carColors": {
+    "_type": "components",
+    "_data": [
+      {
+        "colors": [
+          {
+            "ref": "UEM7Kz5osQ1IU59KOXMvgw",
+            "sliceIds": [
+              "RAL9000"
+            ],
+            "_hash": "rqI5NgAP3yQgBwhMMDhY7m"
+          }
+        ],
+        "_hash": "JVuqfIb-wlp-sPQ0QeN6pO"
+      },
+      {
+        "colors": [
+          {
+            "ref": "UEM7Kz5osQ1IU59KOXMvgw",
+            "sliceIds": [
+              "RAL7000"
+            ],
+            "_hash": "IhEITtf4AGAsDdYiXjHvKI"
+          }
+        ],
+        "_hash": "qN1nFpp02dQ_mE1lQyT0rU"
+      }
+    ],
+    "_hash": "chr8HrNG4vW9nxQXAmFeQu",
+    "tableCfg": "ziiIGGo69M_9jgUu22I73T"
+  },
+  "carColorsLayer": {
+    "_type": "layers",
+    "_data": [
+      {
+        "add": {
+          "car1": "JVuqfIb-wlp-sPQ0QeN6pO",
+          "car2": "qN1nFpp02dQ_mE1lQyT0rU",
+          "car3": "JVuqfIb-wlp-sPQ0QeN6pO",
+          "car4": "qN1nFpp02dQ_mE1lQyT0rU",
+          "_hash": "uLVNF2TtjOIrS3Kt3lrx0U"
+        },
+        "sliceIdsTable": "carSliceId",
+        "sliceIdsTableRow": "qrZ-9U_R84uJbplGsEj3Ns",
+        "componentsTable": "carColors",
+        "_hash": "dB6ZB7cmF_9iTaIe6ih8DE"
+      }
+    ],
+    "_hash": "oaZpOgfQoHWhmPIkZ_iupq",
+    "tableCfg": "JUV9z1lhftUZ5DVxPKqCdX"
+  },
+  "carCake": {
+    "_type": "cakes",
+    "_data": [
+      {
+        "sliceIdsTable": "carSliceId",
+        "sliceIdsRow": "qrZ-9U_R84uJbplGsEj3Ns",
+        "layers": {
+          "carColorRefsLayer": "w7S1giJpHSrAef40mQMmnL",
+          "carSizeLayer": "gEWGBhgXtnmcMsRWcsX8NC",
+          "carColorsLayer": "dB6ZB7cmF_9iTaIe6ih8DE",
+          "_hash": "2VKD4FHTyCUJPHqO1W6PBU"
+        },
+        "_hash": "PxJadFfRk5PedY1lD-PRAT"
+      }
+    ],
+    "tableCfg": "5tcrs9FhrPleZv_JXzetfy",
+    "_hash": "JQcEd52atqBHHX4rcKiQfr"
+  },
+  "colorSliceId": {
+    "_type": "sliceIds",
+    "_data": [
+      {
+        "add": [
+          "RAL9000",
+          "RAL7000"
+        ],
+        "_hash": "8Cl7CQ3A3A7KWUYLGkv1g5"
+      }
+    ],
+    "_hash": "-KHey7eC50Ms-Mb3Dd41ak",
+    "tableCfg": "-Hvv09YoAgL5QIM9t7Cf5Q"
+  },
+  "colorGeneral": {
+    "_data": [
+      {
+        "name": "Black",
+        "_hash": "cIMFhZaDtJAkCF_h3PCCT1"
+      },
+      {
+        "name": "Gray",
+        "_hash": "nxgBIGoNSFZO083VAufXk9"
+      }
+    ],
+    "_type": "components",
+    "_hash": "vIL9LNjY8vM2RR-z3RScU1",
+    "tableCfg": "DN5AwXY-0BHn5Dop6ev6AD"
+  },
+  "colorGeneralLayer": {
+    "_type": "layers",
+    "_data": [
+      {
+        "add": {
+          "RAL9000": "cIMFhZaDtJAkCF_h3PCCT1",
+          "RAL7000": "nxgBIGoNSFZO083VAufXk9",
+          "_hash": "9AEGfK5CuBEJv3PSVAunCn"
+        },
+        "sliceIdsTable": "colorSliceId",
+        "sliceIdsTableRow": "8Cl7CQ3A3A7KWUYLGkv1g5",
+        "componentsTable": "colorGeneral",
+        "_hash": "_Hb9rvFMGppT5tv55GFnHs"
+      }
+    ],
+    "_hash": "C1ZBxmf45GLoKLYhuKhHKX",
+    "tableCfg": "8bFwd1s6GY9Ievq0TEmafH"
+  },
+  "colorGeneralInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "kX_FT5d_o4AajUjmQ3BteX",
+    "_hash": "GVHu3haSPS-_mp4a43HiBD"
+  },
+  "colorGeneralLayerInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "9blCAJPItgOtZ3q2wft292",
+    "_hash": "bSKjSR0Gf-N8Ax0LayZJND"
+  },
+  "colorCakeInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "YSHy0-mZveu_A855-ZvGBC",
+    "_hash": "j7lBtX_FtIi-KcuV6ng3Q5"
+  },
+  "colorSliceIdInsertHistory": {
+    "_type": "insertHistory",
+    "_data": [],
+    "tableCfg": "IZwYQ9HFYCU5-Y3uAGal-h",
+    "_hash": "4TaVXGXbk1BDdbWQ1xsse_"
+  },
+  "colorCakeEdits": {
+    "_type": "edits",
+    "_data": [],
+    "_hash": "Ug7GdEUzrqq2RG46KlPrbZ",
+    "tableCfg": "zfWrUKl7A16AXxyIJewHKA"
+  },
+  "colorCakeMultiEdits": {
+    "_type": "multiEdits",
+    "_data": [],
+    "_hash": "fvjq90ERCEPZ7CR22DoXAp",
+    "tableCfg": "x8AJ4ffTsmQ2nfvAxlVgiX"
+  },
+  "colorCakeEditHistory": {
+    "_type": "editHistory",
+    "_data": [],
+    "_hash": "TVordIynVZCIyk3LpcbMyt",
+    "tableCfg": "T-2ca2y057Fi79TmfE9tbc"
+  },
+  "colorCake": {
+    "_type": "cakes",
+    "_data": [
+      {
+        "sliceIdsTable": "colorSliceId",
+        "sliceIdsRow": "8Cl7CQ3A3A7KWUYLGkv1g5",
+        "layers": {
+          "colorGeneralLayer": "_Hb9rvFMGppT5tv55GFnHs",
+          "_hash": "OhSH-APV85kpA8pgH1cJC8"
+        },
+        "_hash": "UEM7Kz5osQ1IU59KOXMvgw"
+      }
+    ],
+    "tableCfg": "_B0EebPJy0F6OiOjhxyIIL",
+    "_hash": "vvDGucwTOXnC4TCaduFNGD"
+  },
+  "tableCfgs": {
+    "_type": "tableCfgs",
+    "_data": [
+      {
+        "key": "carColorRefsLayer",
+        "type": "layers",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "base",
+            "type": "string",
+            "titleLong": "Base",
+            "titleShort": "Base",
+            "_hash": "EfTZIQZC5xpkbx3LcIDhlS"
+          },
+          {
+            "key": "sliceIdsTable",
+            "type": "string",
+            "titleLong": "Slice Ids Table",
+            "titleShort": "Slice Ids Table",
+            "_hash": "1k77uzMUkjc7tCJlGN31GI"
+          },
+          {
+            "key": "sliceIdsTableRow",
+            "type": "string",
+            "titleLong": "Slice Ids Table Row",
+            "titleShort": "Slice Ids Table Row",
+            "_hash": "b7tMAXjYmRs96pxCcwt812"
+          },
+          {
+            "key": "componentsTable",
+            "type": "string",
+            "titleLong": "Components Table",
+            "titleShort": "Components Table",
+            "_hash": "8oL-bX7Ty76VQFzuIWBrdg"
+          },
+          {
+            "key": "add",
+            "type": "json",
+            "titleLong": "Add",
+            "titleShort": "Add",
+            "_hash": "FZN1kwlNoq9Cv6qIWvNg-3"
+          },
+          {
+            "key": "remove",
+            "type": "json",
+            "titleLong": "Remove",
+            "titleShort": "Remove",
+            "_hash": "UXIjvdKRUxEq3KTXudtaon"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "1vwnm5_U23zQICZu8WRQWM"
+      },
+      {
+        "key": "carColorRefsLayerInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "carColorRefsLayerRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "carColorRefsLayerMultiEdits",
+              "type": "layers",
+              "_hash": "gtdyuiI-1wMAo1-0VqYzNv"
+            },
+            "_hash": "62-h-W7unBiGoUN7Oq1QfW"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "XSGJwbans5KIiwRy-QazyF"
+      },
+      {
+        "key": "carSizeLayer",
+        "type": "layers",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "base",
+            "type": "string",
+            "titleLong": "Base",
+            "titleShort": "Base",
+            "_hash": "EfTZIQZC5xpkbx3LcIDhlS"
+          },
+          {
+            "key": "sliceIdsTable",
+            "type": "string",
+            "titleLong": "Slice Ids Table",
+            "titleShort": "Slice Ids Table",
+            "_hash": "1k77uzMUkjc7tCJlGN31GI"
+          },
+          {
+            "key": "sliceIdsTableRow",
+            "type": "string",
+            "titleLong": "Slice Ids Table Row",
+            "titleShort": "Slice Ids Table Row",
+            "_hash": "b7tMAXjYmRs96pxCcwt812"
+          },
+          {
+            "key": "componentsTable",
+            "type": "string",
+            "titleLong": "Components Table",
+            "titleShort": "Components Table",
+            "_hash": "8oL-bX7Ty76VQFzuIWBrdg"
+          },
+          {
+            "key": "add",
+            "type": "json",
+            "titleLong": "Add",
+            "titleShort": "Add",
+            "_hash": "FZN1kwlNoq9Cv6qIWvNg-3"
+          },
+          {
+            "key": "remove",
+            "type": "json",
+            "titleLong": "Remove",
+            "titleShort": "Remove",
+            "_hash": "UXIjvdKRUxEq3KTXudtaon"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "QnJunuxWX9EcOWlpsOLzQp"
+      },
+      {
+        "key": "carSizeLayerInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "carSizeLayerRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "carSizeLayerMultiEdits",
+              "type": "layers",
+              "_hash": "YAT9HwswTLA7ToaR1KHPOn"
+            },
+            "_hash": "lZmXJLtsbObqtd9f17fCjH"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "wOzWvQb9AKPjrMtluOI65p"
+      },
+      {
+        "key": "carColorRefs",
+        "type": "components",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "colorSliceId",
+            "type": "jsonArray",
+            "titleLong": "ColorSliceId",
+            "titleShort": "colorSliceId",
+            "ref": {
+              "tableKey": "colorSliceId",
+              "type": "sliceIds",
+              "_hash": "dGFYf3koru4zSWpI7JbKbX"
+            },
+            "_hash": "OGGJHM9Ki6ck_m1vuQAVlL"
+          },
+          {
+            "key": "colorGeneral",
+            "type": "string",
+            "titleLong": "ColorGeneral",
+            "titleShort": "colorGeneral",
+            "ref": {
+              "tableKey": "colorGeneral",
+              "type": "components",
+              "_hash": "fChsQm6XkOEso2riUElHFm"
+            },
+            "_hash": "jQbwzG2rsc0sWG0CDz2jlv"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "PI1-B4c1Qcq5yzVBgY3kmc"
+      },
+      {
+        "key": "carColorRefsInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "carColorRefsRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "carColorRefsMultiEdits",
+              "type": "components",
+              "_hash": "rzliwZlUnECd1Ts9ATtbfc"
+            },
+            "_hash": "MRLOaga2fmJ8ztHaqo78Nk"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "8jQV6X1PqZ4BHUuMu2uVq3"
+      },
+      {
+        "key": "carSize",
+        "type": "components",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "size",
+            "type": "string",
+            "titleLong": "Size",
+            "titleShort": "size",
+            "_hash": "87cVICYwhxkqha1E4a4BhP"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "2qSfMPoOctShgHpaKA8V4g"
+      },
+      {
+        "key": "carSizeInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "carSizeRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "carSizeMultiEdits",
+              "type": "components",
+              "_hash": "tDxo4jf-mU1W4NLbUjQSSU"
+            },
+            "_hash": "a8FsaFk1fS4TnkRvq6FNw9"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "rVqlfr04LLtP1q1hwpObC_"
+      },
+      {
+        "key": "carCake",
+        "type": "cakes",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "sliceIdsTable",
+            "type": "string",
+            "titleLong": "Slice Ids Table",
+            "titleShort": "Slice Ids Table",
+            "_hash": "1k77uzMUkjc7tCJlGN31GI"
+          },
+          {
+            "key": "sliceIdsRow",
+            "type": "string",
+            "titleLong": "Slice Ids Row",
+            "titleShort": "Slice Ids Row",
+            "_hash": "T3yH4vS0oUYRZAFPq0eIkc"
+          },
+          {
+            "key": "layers",
+            "type": "json",
+            "titleLong": "Layers",
+            "titleShort": "Layers",
+            "_hash": "DpUNHLADN7AoClIh7IjdUE"
+          },
+          {
+            "key": "id",
+            "type": "string",
+            "titleLong": "ID",
+            "titleShort": "ID",
+            "_hash": "UmazCpc_m0Ww4a9TQd1MpY"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "5tcrs9FhrPleZv_JXzetfy"
+      },
+      {
+        "key": "carCakeInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "carCakeRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "carCakeMultiEdits",
+              "type": "cakes",
+              "_hash": "bIemqBEZsH2-R0bRfmfKf8"
+            },
+            "_hash": "6AvTYsVYY-pFddx3QyJf7b"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "_eXrlfD9KZoKT9R4jdwpxT"
+      },
+      {
+        "key": "carCakeEdits",
+        "type": "edits",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "name",
+            "type": "string",
+            "titleLong": "Name of the Edit",
+            "titleShort": "Name",
+            "_hash": "68dYimY7OxSjVma_WbDdt1"
+          },
+          {
+            "key": "action",
+            "type": "json",
+            "titleLong": "Edit Action Data",
+            "titleShort": "Action",
+            "_hash": "Y_wME1LxPftQx6olWB1AHg"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "rBF6n_3eM0lYFWAII4OwIz"
+      },
+      {
+        "key": "carCakeMultiEdits",
+        "type": "multiEdits",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "previous",
+            "type": "string",
+            "titleLong": "Previous Value",
+            "titleShort": "Previous",
+            "_hash": "OApUMVg0XzxL4rAp8-vHH3"
+          },
+          {
+            "key": "edit",
+            "type": "string",
+            "titleLong": "Edit Reference",
+            "titleShort": "Edit Ref",
+            "ref": {
+              "tableKey": "carCakeEdits",
+              "_hash": "ZQRU0fdOU0dRKS8Cgzp7l1"
+            },
+            "_hash": "HhFD3coIlWO3eYs3n8Ai_L"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "8VfY2MvZQZTl25t-jwr-yH"
+      },
+      {
+        "key": "carCakeEditHistory",
+        "type": "editHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time Identifier",
+            "titleShort": "Time ID",
+            "_hash": "2ej3dpJSAPgLtZjcQ1zj8C"
+          },
+          {
+            "key": "multiEditRef",
+            "type": "string",
+            "titleLong": "Multi Edit Reference",
+            "titleShort": "Multi Edit Ref",
+            "ref": {
+              "tableKey": "carCakeMultiEdits",
+              "_hash": "LCgIOLnmlmw7qOO0jLj0Pm"
+            },
+            "_hash": "ReK6-hptPE6hMz__5RlcJi"
+          },
+          {
+            "key": "dataRef",
+            "type": "string",
+            "titleLong": "Data Reference",
+            "titleShort": "Data Ref",
+            "ref": {
+              "tableKey": "carCake",
+              "_hash": "2l4mut6PepEq0qxY-e8q_1"
+            },
+            "_hash": "HDlEYl8WTKk7HOXCGL8Y-I"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous Values",
+            "titleShort": "Previous",
+            "_hash": "7M8j7b_kcQ6SsWVzcs62fr"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "d_SJjAnmrriCG_D7XSfVyO"
+      },
+      {
+        "key": "carSliceId",
+        "type": "sliceIds",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "base",
+            "type": "string",
+            "titleLong": "Base Slice ID",
+            "titleShort": "Base",
+            "_hash": "o9xR4pvOiAH_Pa2DKOsdTW"
+          },
+          {
+            "key": "add",
+            "type": "jsonArray",
+            "titleLong": "Slice IDs",
+            "titleShort": "IDs",
+            "_hash": "_fblsOPzjZqKHBArTgBNfR"
+          },
+          {
+            "key": "remove",
+            "type": "jsonArray",
+            "titleLong": "Removed Slice IDs",
+            "titleShort": "Removed",
+            "_hash": "2gv0UnQ6-BRjZJ3lsdzvZ1"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "4yM_dWqrCcWxWyt93d4LJx"
+      },
+      {
+        "key": "carSliceIdInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "carSliceIdRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "carSliceIdMultiEdits",
+              "type": "sliceIds",
+              "_hash": "i8o-dhIR5Rwcx1hqWXr07d"
+            },
+            "_hash": "-29olhHYu5jZblRr1n7oAL"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "s-EtjxRq07guJgj8eZbLqe"
+      },
+      {
+        "key": "carColors",
+        "type": "components",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "colors",
+            "type": "jsonArray",
+            "titleLong": "Color References",
+            "titleShort": "Colors",
+            "ref": {
+              "tableKey": "colorCake",
+              "type": "cakes",
+              "_hash": "cb3D9M0f8JelpFUZ2KLKfj"
+            },
+            "_hash": "R0Ach5c-GFMmJQwTHyWTb0"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "ziiIGGo69M_9jgUu22I73T"
+      },
+      {
+        "key": "carColorsInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "carColorsRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "carColorsMultiEdits",
+              "type": "components",
+              "_hash": "qaWLDxhne_0b1DNS8znt99"
+            },
+            "_hash": "zyryWNHcY3rIbP7WCSN2Jn"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "_QS0K--SIdA9jl8oQwQCT1"
+      },
+      {
+        "key": "carColorsLayer",
+        "type": "layers",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "base",
+            "type": "string",
+            "titleLong": "Base",
+            "titleShort": "Base",
+            "_hash": "EfTZIQZC5xpkbx3LcIDhlS"
+          },
+          {
+            "key": "sliceIdsTable",
+            "type": "string",
+            "titleLong": "Slice Ids Table",
+            "titleShort": "Slice Ids Table",
+            "_hash": "1k77uzMUkjc7tCJlGN31GI"
+          },
+          {
+            "key": "sliceIdsTableRow",
+            "type": "string",
+            "titleLong": "Slice Ids Table Row",
+            "titleShort": "Slice Ids Table Row",
+            "_hash": "b7tMAXjYmRs96pxCcwt812"
+          },
+          {
+            "key": "componentsTable",
+            "type": "string",
+            "titleLong": "Components Table",
+            "titleShort": "Components Table",
+            "_hash": "8oL-bX7Ty76VQFzuIWBrdg"
+          },
+          {
+            "key": "add",
+            "type": "json",
+            "titleLong": "Add",
+            "titleShort": "Add",
+            "_hash": "FZN1kwlNoq9Cv6qIWvNg-3"
+          },
+          {
+            "key": "remove",
+            "type": "json",
+            "titleLong": "Remove",
+            "titleShort": "Remove",
+            "_hash": "UXIjvdKRUxEq3KTXudtaon"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "JUV9z1lhftUZ5DVxPKqCdX"
+      },
+      {
+        "key": "carColorsLayerInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "carColorsLayerRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "carColorsLayerMultiEdits",
+              "type": "layers",
+              "_hash": "YzWY9pBUVdjcl-wdo48Za8"
+            },
+            "_hash": "eF-gK908xZFLmTvzKr2931"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "wgy5AnQeSI5pNqMRwNEw1J"
+      },
+      {
+        "key": "colorGeneralLayer",
+        "type": "layers",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "base",
+            "type": "string",
+            "titleLong": "Base",
+            "titleShort": "Base",
+            "_hash": "EfTZIQZC5xpkbx3LcIDhlS"
+          },
+          {
+            "key": "sliceIdsTable",
+            "type": "string",
+            "titleLong": "Slice Ids Table",
+            "titleShort": "Slice Ids Table",
+            "_hash": "1k77uzMUkjc7tCJlGN31GI"
+          },
+          {
+            "key": "sliceIdsTableRow",
+            "type": "string",
+            "titleLong": "Slice Ids Table Row",
+            "titleShort": "Slice Ids Table Row",
+            "_hash": "b7tMAXjYmRs96pxCcwt812"
+          },
+          {
+            "key": "componentsTable",
+            "type": "string",
+            "titleLong": "Components Table",
+            "titleShort": "Components Table",
+            "_hash": "8oL-bX7Ty76VQFzuIWBrdg"
+          },
+          {
+            "key": "add",
+            "type": "json",
+            "titleLong": "Add",
+            "titleShort": "Add",
+            "_hash": "FZN1kwlNoq9Cv6qIWvNg-3"
+          },
+          {
+            "key": "remove",
+            "type": "json",
+            "titleLong": "Remove",
+            "titleShort": "Remove",
+            "_hash": "UXIjvdKRUxEq3KTXudtaon"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "8bFwd1s6GY9Ievq0TEmafH"
+      },
+      {
+        "key": "colorGeneralLayerInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "colorGeneralLayerRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "colorGeneralLayerMultiEdits",
+              "type": "layers",
+              "_hash": "4UCUYeDWWM8h_TDI6HLsjx"
+            },
+            "_hash": "j-IZDp52k-UUGxFB6fzQoW"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "9blCAJPItgOtZ3q2wft292"
+      },
+      {
+        "key": "colorGeneral",
+        "type": "components",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "name",
+            "type": "string",
+            "titleLong": "Name",
+            "titleShort": "name",
+            "_hash": "zpGBxObOneWRf8WlRfe0wT"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "DN5AwXY-0BHn5Dop6ev6AD"
+      },
+      {
+        "key": "colorGeneralInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "colorGeneralRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "colorGeneralMultiEdits",
+              "type": "components",
+              "_hash": "yjWLl9FY8nbXkZ_0eI3yfL"
+            },
+            "_hash": "0Cg_O7NDphKI1uzBtPV3Gr"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "kX_FT5d_o4AajUjmQ3BteX"
+      },
+      {
+        "key": "colorCake",
+        "type": "cakes",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "sliceIdsTable",
+            "type": "string",
+            "titleLong": "Slice Ids Table",
+            "titleShort": "Slice Ids Table",
+            "_hash": "1k77uzMUkjc7tCJlGN31GI"
+          },
+          {
+            "key": "sliceIdsRow",
+            "type": "string",
+            "titleLong": "Slice Ids Row",
+            "titleShort": "Slice Ids Row",
+            "_hash": "T3yH4vS0oUYRZAFPq0eIkc"
+          },
+          {
+            "key": "layers",
+            "type": "json",
+            "titleLong": "Layers",
+            "titleShort": "Layers",
+            "_hash": "DpUNHLADN7AoClIh7IjdUE"
+          },
+          {
+            "key": "id",
+            "type": "string",
+            "titleLong": "ID",
+            "titleShort": "ID",
+            "_hash": "UmazCpc_m0Ww4a9TQd1MpY"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "_B0EebPJy0F6OiOjhxyIIL"
+      },
+      {
+        "key": "colorCakeInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "colorCakeRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "colorCakeMultiEdits",
+              "type": "cakes",
+              "_hash": "bzoeSrYfFHqUbc5bN5hMkF"
+            },
+            "_hash": "Xm8fSyQ-kq82ZS70W0Tg6C"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "YSHy0-mZveu_A855-ZvGBC"
+      },
+      {
+        "key": "colorCakeEdits",
+        "type": "edits",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "name",
+            "type": "string",
+            "titleLong": "Name of the Edit",
+            "titleShort": "Name",
+            "_hash": "68dYimY7OxSjVma_WbDdt1"
+          },
+          {
+            "key": "action",
+            "type": "json",
+            "titleLong": "Edit Action Data",
+            "titleShort": "Action",
+            "_hash": "Y_wME1LxPftQx6olWB1AHg"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "zfWrUKl7A16AXxyIJewHKA"
+      },
+      {
+        "key": "colorCakeMultiEdits",
+        "type": "multiEdits",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "previous",
+            "type": "string",
+            "titleLong": "Previous Value",
+            "titleShort": "Previous",
+            "_hash": "OApUMVg0XzxL4rAp8-vHH3"
+          },
+          {
+            "key": "edit",
+            "type": "string",
+            "titleLong": "Edit Reference",
+            "titleShort": "Edit Ref",
+            "ref": {
+              "tableKey": "colorCakeEdits",
+              "_hash": "LlHlHUJgLSb8yOS1SmjGEd"
+            },
+            "_hash": "42SqviOM_X_HI7FQsG8g6X"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "x8AJ4ffTsmQ2nfvAxlVgiX"
+      },
+      {
+        "key": "colorCakeEditHistory",
+        "type": "editHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time Identifier",
+            "titleShort": "Time ID",
+            "_hash": "2ej3dpJSAPgLtZjcQ1zj8C"
+          },
+          {
+            "key": "multiEditRef",
+            "type": "string",
+            "titleLong": "Multi Edit Reference",
+            "titleShort": "Multi Edit Ref",
+            "ref": {
+              "tableKey": "colorCakeMultiEdits",
+              "_hash": "7S7rF3OmRV7CPyAphWKINf"
+            },
+            "_hash": "XJH1ipnfmyBnL2c_KEbiCs"
+          },
+          {
+            "key": "dataRef",
+            "type": "string",
+            "titleLong": "Data Reference",
+            "titleShort": "Data Ref",
+            "ref": {
+              "tableKey": "colorCake",
+              "_hash": "eK5R1wktjAWuql_65eZn5V"
+            },
+            "_hash": "4JwfBARQqGnlDCHKl59q4C"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous Values",
+            "titleShort": "Previous",
+            "_hash": "7M8j7b_kcQ6SsWVzcs62fr"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": true,
+        "_hash": "T-2ca2y057Fi79TmfE9tbc"
+      },
+      {
+        "key": "colorSliceId",
+        "type": "sliceIds",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "base",
+            "type": "string",
+            "titleLong": "Base Slice ID",
+            "titleShort": "Base",
+            "_hash": "o9xR4pvOiAH_Pa2DKOsdTW"
+          },
+          {
+            "key": "add",
+            "type": "jsonArray",
+            "titleLong": "Slice IDs",
+            "titleShort": "IDs",
+            "_hash": "_fblsOPzjZqKHBArTgBNfR"
+          },
+          {
+            "key": "remove",
+            "type": "jsonArray",
+            "titleLong": "Removed Slice IDs",
+            "titleShort": "Removed",
+            "_hash": "2gv0UnQ6-BRjZJ3lsdzvZ1"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "-Hvv09YoAgL5QIM9t7Cf5Q"
+      },
+      {
+        "key": "colorSliceIdInsertHistory",
+        "type": "insertHistory",
+        "columns": [
+          {
+            "key": "_hash",
+            "type": "string",
+            "titleLong": "Hash",
+            "titleShort": "Hash",
+            "_hash": "Np5O9L6tfUaUFTAYyx6g5E"
+          },
+          {
+            "key": "timeId",
+            "type": "string",
+            "titleLong": "Time ID",
+            "titleShort": "Time ID",
+            "_hash": "h3f2KT-46nyCtBx3cx3P-r"
+          },
+          {
+            "key": "colorSliceIdRef",
+            "type": "string",
+            "titleLong": "Reference",
+            "titleShort": "Ref",
+            "ref": {
+              "tableKey": "colorSliceIdMultiEdits",
+              "type": "sliceIds",
+              "_hash": "ZY2iAk-ZoqSdS4dM4_-MsE"
+            },
+            "_hash": "xwjAtY_wFiujOV0tW279m3"
+          },
+          {
+            "key": "route",
+            "type": "string",
+            "titleLong": "Route",
+            "titleShort": "Route",
+            "_hash": "Vn9lhEP3B4VYT2iRPuknGj"
+          },
+          {
+            "key": "origin",
+            "type": "string",
+            "titleLong": "Origin",
+            "titleShort": "Origin",
+            "_hash": "kUSefbcu2Ozrq2HKvZTpRz"
+          },
+          {
+            "key": "previous",
+            "type": "jsonArray",
+            "titleLong": "Previous",
+            "titleShort": "Previous",
+            "_hash": "BTy3s7x-cGnl0N0i1rY2wG"
+          },
+          {
+            "key": "clientTimestamp",
+            "type": "number",
+            "titleLong": "Client Timestamp",
+            "titleShort": "Timestamp",
+            "_hash": "mI4GW4A-kgoF3gpk3ktkrc"
+          }
+        ],
+        "isHead": false,
+        "isRoot": false,
+        "isShared": false,
+        "_hash": "IZwYQ9HFYCU5-Y3uAGal-h"
+      }
+    ],
+    "_hash": "JTnbP-PdnAe7CrwEmpU5_T"
+  },
+  "_hash": "R8BnHQBL3IUkKFdeX4ubcr"
+}

--- a/test/goldens/example/converter/list-with-types-multi-ref.json
+++ b/test/goldens/example/converter/list-with-types-multi-ref.json
@@ -150,19 +150,19 @@
       {
         "screws": [
           {
-            "ref": "HU6A9ixXjdFxzhBo8jeAl5",
+            "ref": "LmTMIBDtOhkRpUVgupxUsp",
             "sliceIds": [
               "SCW-001",
               "SCW-001",
               "SCW-002"
             ],
-            "_hash": "eYwr2KGMcuBGdSA9XKiNuj"
+            "_hash": "eWinEY5iVJZhnOkIG_0hl1"
           }
         ],
-        "_hash": "S_p0z5Mll6kAAsw1bZEKMi"
+        "_hash": "Wi11MMx6xh85QYZQ3KWDQ7"
       }
     ],
-    "_hash": "Oq5NJNeqWHZPscxOJkHrmr",
+    "_hash": "Nchu6weN9dayrKaN0hYllR",
     "tableCfg": "Bd_bBqfRfoYn-3WdIX7y0d"
   },
   "carScrewsLayer": {
@@ -170,16 +170,16 @@
     "_data": [
       {
         "add": {
-          "car1": "S_p0z5Mll6kAAsw1bZEKMi",
-          "_hash": "dMBHlks3EgIH5sncADFLcM"
+          "car1": "Wi11MMx6xh85QYZQ3KWDQ7",
+          "_hash": "IdtMiplycM25p4bZIDbQHc"
         },
         "sliceIdsTable": "carSliceId",
         "sliceIdsTableRow": "kDDxr90W7nJNEn8p2X5Hbl",
         "componentsTable": "carScrews",
-        "_hash": "P8mwUHjJF-7t_jVaZgAafs"
+        "_hash": "1UmENDkXbwfKTkMN-2EAGx"
       }
     ],
-    "_hash": "NQnX5ys88kuPBBEd9ChORp",
+    "_hash": "DjajEBpyvcAvIp10vmK83R",
     "tableCfg": "UBr_r7Ge7Vn_uRuaQkg-hn"
   },
   "carCake": {
@@ -191,14 +191,14 @@
         "layers": {
           "carMetaLayer": "6nmN98POuTqRn79mRFaYyQ",
           "carScrewRefsLayer": "1R-WghUnKo6un0karMMnUs",
-          "carScrewsLayer": "P8mwUHjJF-7t_jVaZgAafs",
-          "_hash": "pa9PL08yIAhdIwZtgPkO0X"
+          "carScrewsLayer": "1UmENDkXbwfKTkMN-2EAGx",
+          "_hash": "mpxfZLzey91Wbj4NB4dtN7"
         },
-        "_hash": "9LwXCudYBy4BYqyLQ9a9Db"
+        "_hash": "CJfFHRuN9OX0GZtxZvBMFh"
       }
     ],
     "tableCfg": "5tcrs9FhrPleZv_JXzetfy",
-    "_hash": "BVOFMTH7THNU9g4gWzJGxm"
+    "_hash": "v5RkPIaf26DvxYN-dA7MMi"
   },
   "screwSliceId": {
     "_type": "sliceIds",
@@ -206,13 +206,12 @@
       {
         "add": [
           "SCW-001",
-          "SCW-001",
           "SCW-002"
         ],
-        "_hash": "xUloAEA4YX0vxsvmbQSmgZ"
+        "_hash": "mHlLicXXAWwwgqKj9SZlz-"
       }
     ],
-    "_hash": "K8NeoN1qM78KzxTPVKxw2z",
+    "_hash": "ule48vS4DtJhuAl9VPilXe",
     "tableCfg": "izkhRcql5wabLhmbpEaMf8"
   },
   "screwTechnical": {
@@ -244,12 +243,12 @@
           "_hash": "tLh_mRFVOBg_wQ0IjWzLJC"
         },
         "sliceIdsTable": "screwSliceId",
-        "sliceIdsTableRow": "xUloAEA4YX0vxsvmbQSmgZ",
+        "sliceIdsTableRow": "mHlLicXXAWwwgqKj9SZlz-",
         "componentsTable": "screwTechnical",
-        "_hash": "uYHoXEKloDRV4ZjpEJ8iLJ"
+        "_hash": "hy9qV4D_k1Gm9lKQVakomD"
       }
     ],
-    "_hash": "H2N6lhE3w2RK8r4UKxfJcV",
+    "_hash": "ePUQNg88CXuXDjkhegEpxH",
     "tableCfg": "zg_fEuvUGUE61xdtb5xQWS"
   },
   "screwTechnicalInsertHistory": {
@@ -299,16 +298,16 @@
     "_data": [
       {
         "sliceIdsTable": "screwSliceId",
-        "sliceIdsRow": "xUloAEA4YX0vxsvmbQSmgZ",
+        "sliceIdsRow": "mHlLicXXAWwwgqKj9SZlz-",
         "layers": {
-          "screwTechnicalLayer": "uYHoXEKloDRV4ZjpEJ8iLJ",
-          "_hash": "OURHBM1RcNqBcv2NkPn_lB"
+          "screwTechnicalLayer": "hy9qV4D_k1Gm9lKQVakomD",
+          "_hash": "5lRHPKnaY9d07ApcspRg6W"
         },
-        "_hash": "HU6A9ixXjdFxzhBo8jeAl5"
+        "_hash": "LmTMIBDtOhkRpUVgupxUsp"
       }
     ],
     "tableCfg": "CdUr4i-a1UDjkV-Kf6qyJB",
-    "_hash": "ooLFy48GQzb8A84VcMN33M"
+    "_hash": "SOgxiFz8FD7K3fjOo9VoBA"
   },
   "tableCfgs": {
     "_type": "tableCfgs",
@@ -1863,5 +1862,5 @@
     ],
     "_hash": "gUicNUV0cV3O1Mh-DSitz2"
   },
-  "_hash": "FP3Ts6rkBQtpxwLV9grKfE"
+  "_hash": "fxGrmpLIg24u3Wp2tk_FXz"
 }

--- a/test/goldens/example/converter/list-with-types-named-multi-ref.json
+++ b/test/goldens/example/converter/list-with-types-named-multi-ref.json
@@ -160,19 +160,19 @@
       {
         "screws": [
           {
-            "ref": "HU6A9ixXjdFxzhBo8jeAl5",
+            "ref": "LmTMIBDtOhkRpUVgupxUsp",
             "sliceIds": [
               "SCW-001",
               "SCW-001",
               "SCW-002"
             ],
-            "_hash": "eYwr2KGMcuBGdSA9XKiNuj"
+            "_hash": "eWinEY5iVJZhnOkIG_0hl1"
           }
         ],
-        "_hash": "S_p0z5Mll6kAAsw1bZEKMi"
+        "_hash": "Wi11MMx6xh85QYZQ3KWDQ7"
       }
     ],
-    "_hash": "Oq5NJNeqWHZPscxOJkHrmr",
+    "_hash": "Nchu6weN9dayrKaN0hYllR",
     "tableCfg": "Bd_bBqfRfoYn-3WdIX7y0d"
   },
   "carScrewsLayer": {
@@ -180,16 +180,16 @@
     "_data": [
       {
         "add": {
-          "car1": "S_p0z5Mll6kAAsw1bZEKMi",
-          "_hash": "dMBHlks3EgIH5sncADFLcM"
+          "car1": "Wi11MMx6xh85QYZQ3KWDQ7",
+          "_hash": "IdtMiplycM25p4bZIDbQHc"
         },
         "sliceIdsTable": "carSliceId",
         "sliceIdsTableRow": "kDDxr90W7nJNEn8p2X5Hbl",
         "componentsTable": "carScrews",
-        "_hash": "P8mwUHjJF-7t_jVaZgAafs"
+        "_hash": "1UmENDkXbwfKTkMN-2EAGx"
       }
     ],
-    "_hash": "NQnX5ys88kuPBBEd9ChORp",
+    "_hash": "DjajEBpyvcAvIp10vmK83R",
     "tableCfg": "UBr_r7Ge7Vn_uRuaQkg-hn"
   },
   "carCake": {
@@ -201,14 +201,14 @@
         "layers": {
           "carMetaLayer": "6nmN98POuTqRn79mRFaYyQ",
           "carScrewRefsLayer": "gVep6lHbcVkwcRcVYSe-bG",
-          "carScrewsLayer": "P8mwUHjJF-7t_jVaZgAafs",
-          "_hash": "GPmSoajyW3xuSvd_scpQyD"
+          "carScrewsLayer": "1UmENDkXbwfKTkMN-2EAGx",
+          "_hash": "D20J-8aehVy6RKHXV1vXun"
         },
-        "_hash": "ibNiVjVMiXmqGk2raQGDWV"
+        "_hash": "FjNwv3lzNIuRFgWwOety3T"
       }
     ],
     "tableCfg": "5tcrs9FhrPleZv_JXzetfy",
-    "_hash": "laLvgL6JhxBbQtD9kT9MYc"
+    "_hash": "hU7QY_djgOtgWHaV0fTfhc"
   },
   "screwSliceId": {
     "_type": "sliceIds",
@@ -216,13 +216,12 @@
       {
         "add": [
           "SCW-001",
-          "SCW-001",
           "SCW-002"
         ],
-        "_hash": "xUloAEA4YX0vxsvmbQSmgZ"
+        "_hash": "mHlLicXXAWwwgqKj9SZlz-"
       }
     ],
-    "_hash": "K8NeoN1qM78KzxTPVKxw2z",
+    "_hash": "ule48vS4DtJhuAl9VPilXe",
     "tableCfg": "izkhRcql5wabLhmbpEaMf8"
   },
   "screwTechnical": {
@@ -254,12 +253,12 @@
           "_hash": "tLh_mRFVOBg_wQ0IjWzLJC"
         },
         "sliceIdsTable": "screwSliceId",
-        "sliceIdsTableRow": "xUloAEA4YX0vxsvmbQSmgZ",
+        "sliceIdsTableRow": "mHlLicXXAWwwgqKj9SZlz-",
         "componentsTable": "screwTechnical",
-        "_hash": "uYHoXEKloDRV4ZjpEJ8iLJ"
+        "_hash": "hy9qV4D_k1Gm9lKQVakomD"
       }
     ],
-    "_hash": "H2N6lhE3w2RK8r4UKxfJcV",
+    "_hash": "ePUQNg88CXuXDjkhegEpxH",
     "tableCfg": "zg_fEuvUGUE61xdtb5xQWS"
   },
   "screwTechnicalInsertHistory": {
@@ -309,16 +308,16 @@
     "_data": [
       {
         "sliceIdsTable": "screwSliceId",
-        "sliceIdsRow": "xUloAEA4YX0vxsvmbQSmgZ",
+        "sliceIdsRow": "mHlLicXXAWwwgqKj9SZlz-",
         "layers": {
-          "screwTechnicalLayer": "uYHoXEKloDRV4ZjpEJ8iLJ",
-          "_hash": "OURHBM1RcNqBcv2NkPn_lB"
+          "screwTechnicalLayer": "hy9qV4D_k1Gm9lKQVakomD",
+          "_hash": "5lRHPKnaY9d07ApcspRg6W"
         },
-        "_hash": "HU6A9ixXjdFxzhBo8jeAl5"
+        "_hash": "LmTMIBDtOhkRpUVgupxUsp"
       }
     ],
     "tableCfg": "CdUr4i-a1UDjkV-Kf6qyJB",
-    "_hash": "ooLFy48GQzb8A84VcMN33M"
+    "_hash": "SOgxiFz8FD7K3fjOo9VoBA"
   },
   "tableCfgs": {
     "_type": "tableCfgs",
@@ -1897,5 +1896,5 @@
     ],
     "_hash": "D9z31jqmXdKiGYAgbF_KQN"
   },
-  "_hash": "oNNS7461pOXYpCnRYT53uQ"
+  "_hash": "qtaQ2YJn2dH5k7x0Df9c-9"
 }


### PR DESCRIPTION
## Summary
- Add a converter test covering a flat scalar component (`size`) mixed with sliceId/general color references, including items with no size value.
- Fix a latent bug where two sibling items with identical content and no natural `_sliceId` collapsed into the same fallback sliceId (previously an accepted, documented tradeoff). The item's array position is now folded into the fallback content hash, keeping such items distinct.
- With that fixed, every `sliceIds` table's `add` list is now fully deduplicated — any remaining duplicate can only come from genuine natural-key reuse across items (intentional normalization), not accidental fallback collisions.
- Update `README.public.md`'s SliceId Fallback section to describe the corrected behavior.

## Test plan
- [x] `pnpm test` — 44/45 tests pass (1 pre-existing unrelated expected-fail), 100% coverage (statements/branches/functions/lines)
- [x] `pnpm exec eslint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm run build` succeeds